### PR TITLE
Add GOV.UK rebrand

### DIFF
--- a/app/assets/styles.scss
+++ b/app/assets/styles.scss
@@ -4,6 +4,10 @@
 // Use GOV.UK Eleventy Plugin components
 @use "pkg:@x-govuk/govuk-eleventy-plugin";
 
+.govuk-footer {
+  font-size: 19px;
+}
+
 .style-a-z {
   padding-left: 0px;
   margin-bottom: 30px;

--- a/app/assets/styles.scss
+++ b/app/assets/styles.scss
@@ -6,6 +6,7 @@
 
 .govuk-footer {
   font-size: 19px;
+  line-height: 25px;
 }
 
 .style-a-z {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -9,7 +9,7 @@ export default function(eleventyConfig) {
     stylesheets: [
       '/assets/styles.css'
     ],
-    rebrand: false,
+    rebrand: true,
     header: {
       productName: 'Content and publishing guidance',
       search: {


### PR DESCRIPTION
- turns on GOV.UK rebrand
- makes footer font size consistent with GOV.UK