### PR TITLE
Fix 'engines' definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "govuk-content-publishing-guidance",
   "type": "module",
   "engines": {
-    "node": "^22.11.0",
-    "npm": "^10.1.0"
+    "node": ">=22.11.0 <23",
+    "npm": ">=10.1.0 <11"
   },
   "scripts": {
     "start": "npx @11ty/eleventy --serve",


### PR DESCRIPTION
The provided values weren't valid, according to the [documentation](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines).

This manifested in a [failed Dependabot update](https://github.com/alphagov/govuk-content-publishing-guidance/actions/runs/16462133830/job/46531507420):

```
updater | 2025/07/23 05:14:27 INFO <job_1059781197> Installed version for npm: 10.5.0
2025/07/23 05:14:27 INFO <job_1059781197> Processing engine constraints for npm
updater | 2025/07/23 05:14:27 INFO <job_1059781197> Parsed constraints for npm: >=10.1.0 <11.0.0
updater | 2025/07/23 05:14:27 ERROR <job_1059781197> Error processing constraints for npm: Illformed requirement [">=10.1.0 <11.0.0"]
```

JIRA: WHIT-2326
Zendesk: https://govuk.zendesk.com/agent/tickets/6179089