### PR TITLE
Design updates for v7.1.1 of the plugin

### DIFF
--- a/_includes/layouts/collection.njk
+++ b/_includes/layouts/collection.njk
@@ -5,12 +5,12 @@
   <div class="govuk-width-container">
     {% include "layouts/shared/phase-banner.njk" %}
       {{ govukBreadcrumbs({
-    classes: "govuk-breadcrumbs--inverse govuk-!-display-none-print",
+    classes: "govuk-!-display-none-print",
     items: breadcrumbItems
   }) if showBreadcrumbs }}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
-      <span class="govuk-caption-xl govuk-caption--inverse govuk-!-margin-top-6">Collection</span>
+      <span class="govuk-caption-xl govuk-!-margin-top-6">Collection</span>
         {% if title %}
         <h1 class="x-govuk-masthead__title govuk-!-margin-top-0">
           {{ title | smart }}

--- a/_includes/layouts/homepage.njk
+++ b/_includes/layouts/homepage.njk
@@ -2,7 +2,7 @@
 
 {% block main %}
   <main id="main-content" role="main" {%- if mainLang %} lang="{{ mainLang }}"{% endif %}>
-<div class="x-govuk-masthead">
+<div class="x-govuk-masthead x-govuk-masthead--inverse">
   <div class="govuk-width-container">
     {% include "layouts/shared/phase-banner.njk" %}
       {{ govukBreadcrumbs({
@@ -35,16 +35,16 @@
         {% block content %}
         
           {% if whatsNew and whatsNewDate %}
-            <section class="doc-whatsNew">
+            <section class="app-whatsNew">
               <h2 class="govuk-heading-l">What's new</h2>
-              <p class="govuk-body">{{ whatsNewDate }}</p>
+              <h3 class="govuk-heading-s">{{ whatsNewDate }}{% if whatsNewHeadline %}: {{ whatsNewHeadline }}{% endif %}</p>
               <p class="govuk-body">{{ whatsNew | markdown }}</p>
             </section>
             <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
           {% endif %}
 
           {% if gridItems %}
-            <section class="doc-items">
+            <section class="app-items">
             <h2 class="govuk-heading-l">Featured</h2>
               <div class="govuk-grid-row">
                 {% for item in gridItems %}
@@ -69,7 +69,7 @@
           {% if additionalInfo %}
           {% for item in additionalInfo %}
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-            <section class="doc-additional-info">
+            <section class="app-additional-info">
               <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                   <h2 class="govuk-heading-l">{{ item.title }}</h2>

--- a/_includes/layouts/shared/phase-banner.njk
+++ b/_includes/layouts/shared/phase-banner.njk
@@ -1,11 +1,11 @@
-<div class="govuk-phase-banner{% if layout == "collection" or layout == "homepage" %} x-govuk-phase-banner--inverse{% endif %}">
+<div class="govuk-phase-banner">
       <p class="govuk-phase-banner__content">
-        <strong class="govuk-tag govuk-phase-banner__content__tag{% if layout == "collection" or layout == "homepage" %} x-govuk-tag--inverse{% endif %}">
+        <strong class="govuk-tag govuk-phase-banner__content__tag">
           Alpha
         </strong>
         <span class="govuk-phase-banner__text">
-        This guidance is in development. You can find <a href="https://www.gov.uk/government/collections/content-and-publishing-guidance-for-government" class="govuk-link{% if layout == "collection" or layout == "homepage" %} govuk-link--inverse{% endif %}">current content and publishing guidance on GOV.UK</a>.
-        <!-- This guidance is new. Help us improve it and <a href="#" class="govuk-link{% if layout == "collection" or layout == "homepage" %} govuk-link--inverse{% endif %}" rel="noreferrer noopener" target="_blank">give your feedback (opens in new tab)</a>. -->
+        This guidance is in development. You can find <a href="https://www.gov.uk/government/collections/content-and-publishing-guidance-for-government" class="govuk-link">current content and publishing guidance on GOV.UK</a>.
+        <!-- This guidance is new. Help us improve it and <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">give your feedback (opens in new tab)</a>. -->
         </span>
       </p>
     </div>

--- a/_includes/layouts/tags.njk
+++ b/_includes/layouts/tags.njk
@@ -16,14 +16,18 @@
       title: title or "Tags"
     }) }}
 
+    {% if collections.tags | length > 0 %}
     <ul class="govuk-list govuk-list--bullet">
       {% for tag in collections.tags %}
       <li>
-        <a href="/tags/{{ tag | slug }}">{{ tag }}</a>
+        <a class="govuk-link" href="/tags/{{ tag | slug }}">{{ tag }}</a>
         ({{ collections[tag] | length }})
       </li>
       {% endfor %}
     </ul>
+    {% else %}
+    <p class="govuk-body">No tags found.</p>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/app/index.md
+++ b/app/index.md
@@ -5,8 +5,10 @@ title: Home
 customPageTitle: Guidance and good practice for publishers on GOV.UK
 description: Find guidance about how to write to GOV.UK standards, use publishing applications and how to request support.
 eleventyExcludeFromCollections: false
-whatsNew: 
+inverseMasthead: true
 whatsNewDate: 
+whatsNewHeadline: 
+whatsNew: 
 gridItems:
   - title: Style guides
     description: Style, spelling and grammar conventions for all content published on GOV.UK.


### PR DESCRIPTION
This pull request:

- removes inverse on breadcrumbs and caption on the collection page layout
- inverses the masthead on the homepage and adds a new headline section to the what's new section
- removes 'if' statements from the phase banner for inverse as this is now managed through individual pages and the layout
- adds a new what's new headline option and sets inverse for homepage

This PR also updates the tags layout to match the plugin.