### PR TITLE
Add search tracking [WHIT-2478]

### DIFF
--- a/_includes/javascripts/analytics.mjs
+++ b/_includes/javascripts/analytics.mjs
@@ -1,6 +1,46 @@
 // from https://github.com/alphagov/govuk-design-system/blob/main/src/javascripts/components/analytics.mjs
 
-export function loadAnalytics() {  
+import { getConsentCookie, isValidConsentCookie } from './cookie-functions.mjs'
+
+/**
+ * Push to Google Analytics
+ *
+ * @param {object} payload - Google Analytics payload
+ */
+export function addToDataLayer(payload) {
+  // @ts-expect-error Property does not exist on window
+  window.dataLayer = window.dataLayer || []
+  // @ts-expect-error Property does not exist on window
+  window.dataLayer.push({
+    ...payload,
+    timestamp: Date.now().toString()
+  })
+}
+
+/**
+ * Strip possible personally identifiable information (PII)
+ *
+ * @param {string} string - Input string
+ * @returns {string} Output string
+ */
+export function stripPossiblePII(string) {
+  // Try to detect emails, postcodes, and NI numbers, and redact them.
+  // Regexes copied from GTM variable 'JS - Remove PII from Hit Payload'
+  string = string.replace(/[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g, '[REDACTED EMAIL]')
+  string = string.replace(
+    /\b[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}\b/gi,
+    '[REDACTED POSTCODE]'
+  )
+  string = string.replace(
+    /^\s*[a-zA-Z]{2}(?:\s*\d\s*){6}[a-zA-Z]?\s*$/g,
+    '[REDACTED NI NUMBER]'
+  )
+  // If someone has typed in a number it's likely not related so redact it
+  string = string.replace(/[0-9]+/g, '[REDACTED NUMBER]')
+  return string
+}
+
+export function loadAnalytics() {
   if (!window.ga || !window.ga.loaded) {
     // Load gtm script
     // Script based on snippet at https://developers.google.com/tag-manager/quickstart
@@ -20,4 +60,27 @@ export function loadAnalytics() {
       document.head.appendChild(j)
     })(window, document, 'script', 'dataLayer', 'GTM-NDQ4DC87')
   }
+}
+
+export function cookiesAccepted() {
+  const userConsent = getConsentCookie()
+
+  return userConsent && isValidConsentCookie(userConsent) && userConsent.analytics
+}
+
+// https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+// to get the same event structure as used on GOV.UK, sadly not an importable
+// module so need to hardcode this copy-and-paste (and update it if changes) :(
+export const ecommerceSchema = {
+  event: null,
+  search_results: {
+    event_name: null,
+    term: null,
+    sort: null,
+    results: null,
+    ecommerce: {
+      items: null
+    }
+  },
+  event_data: null
 }

--- a/_includes/javascripts/application.mjs
+++ b/_includes/javascripts/application.mjs
@@ -1,5 +1,14 @@
-import { loadAnalytics } from './analytics.mjs';
+import { loadAnalytics, cookiesAccepted } from './analytics.mjs';
 import { getConsentCookie, isValidConsentCookie } from './cookie-functions.mjs'
 import CookieBanner from './cookie-banner.mjs';
 import CookiesPage from './cookies-page.mjs';
 import { createAll } from 'govuk-frontend';
+import SearchTracker from './search-tracker.mjs';
+
+const initialiseAnalytics = () => {
+  if (cookiesAccepted()) {
+    loadAnalytics()
+  }
+
+  createAll(SearchTracker)
+}

--- a/_includes/javascripts/cookie-functions.mjs
+++ b/_includes/javascripts/cookie-functions.mjs
@@ -11,6 +11,8 @@
  */
 
 import { loadAnalytics } from './analytics.mjs'
+import { createAll } from 'govuk-frontend'
+import SearchTracker from './search-tracker.mjs'
 
 /* Name of the cookie to save users cookie preferences to. */
 const CONSENT_COOKIE_NAME = 'content_and_publishing_guidance_policy'
@@ -126,6 +128,7 @@ export function resetCookies() {
       window[`ga-disable-G-${TRACKING_PREVIEW_ID}`] = false
       window[`ga-disable-G-${TRACKING_LIVE_ID}`] = false
       loadAnalytics()
+      createAll(SearchTracker)
     } else {
       // Disable GA if not allowed
       window[`ga-disable-G-${TRACKING_PREVIEW_ID}`] = true

--- a/_includes/javascripts/search-tracker.mjs
+++ b/_includes/javascripts/search-tracker.mjs
@@ -1,0 +1,92 @@
+import { Component } from 'govuk-frontend'
+import { cookiesAccepted, addToDataLayer, stripPossiblePII, ecommerceSchema } from './analytics.mjs'
+
+class SearchTracker extends Component {
+  static checkSupport() {
+    super.checkSupport()
+
+    if (!cookiesAccepted()) {
+      throw Error('Cancelled initialisation as cookies not accepted')
+    }
+  }
+
+  static moduleName = 'search-tracker'
+
+  constructor($root) {
+    super($root)
+
+    this.siteSearch = this.$root.querySelector('site-search')
+
+    this.siteSearch.addEventListener("input", this.trackSearch.bind(this))
+    this.siteSearch.addEventListener("click", this.trackConfirm.bind(this))
+  }
+
+  formatResults (item_list_name, results) {
+    return results.map((searchResult, index) => ({
+      item_name: searchResult.childNodes[0].nodeValue,
+      item_list_name,
+      index
+    }))
+  }
+
+  // based on the search tracking from alphagov#govuk-design-system
+  // https://github.com/alphagov/govuk-design-system/blob/main/src/javascripts/components/search.tracking.mjs
+  trackSearch({ target }) {
+    const searchTerm = target.value
+    let inputDebounceTimer = null
+
+    clearTimeout(inputDebounceTimer)
+
+    inputDebounceTimer = setTimeout(() => {
+      const searchResults = this.siteSearch.querySelectorAll('#app-site-search__input__listbox li');
+
+      addToDataLayer({
+        event: "event_data",
+        event_data: {
+          action: "search",
+          event_name: "search",
+          text: searchTerm,
+          url: window.location.pathname,
+        }
+      })
+
+      this.trackSearchInteraction(searchTerm, this.formatResults(searchTerm, [...searchResults]))
+    }, 100)
+  }
+
+  // based on the search tracking from alphagov#govuk-design-system
+  // https://github.com/alphagov/govuk-design-system/blob/main/src/javascripts/components/search.tracking.mjs
+  trackConfirm({ target }) {
+    if (target.closest(".app-site-search__option")) {
+      const searchTerm = this.siteSearch.querySelector('input').value
+      const searchResults = this.siteSearch.querySelectorAll('#app-site-search__input__listbox li')
+      this.trackSearchInteraction(searchTerm, this.formatResults(searchTerm, [...searchResults]), target.childNodes[0].nodeValue)
+    }
+  }
+
+  // based on the search tracking from alphagov#govuk-design-system
+  // https://github.com/alphagov/govuk-design-system/blob/main/src/javascripts/components/search.tracking.mjs
+  trackSearchInteraction(searchTerm, searchResults, clickedItem) {
+    const data = { ...ecommerceSchema }
+
+    if ('DO_NOT_TRACK_ENABLED' in window && window.DO_NOT_TRACK_ENABLED) {
+      return
+    }
+
+    const items = clickedItem ? [searchResults.find(({ item_name }) => clickedItem == item_name)] : searchResults
+
+    data.event = 'search_results'
+    data.event_data = { external: false }
+    data.search_results = {
+      event_name: clickedItem ? 'select_item' : 'view_item_list',
+      results: searchResults.length,
+      term: stripPossiblePII(searchTerm),
+      ecommerce: { items }
+    }
+
+    addToDataLayer({ search_results: { ecommerce: null } })
+    addToDataLayer(data)
+  }
+}
+
+export default SearchTracker

--- a/_includes/layouts/main.njk
+++ b/_includes/layouts/main.njk
@@ -3,6 +3,12 @@
 {# Extend GOV.UK Eleventy Plugin base layout #}
 {% extends "layouts/base.njk" %}
 
+{% block header %}
+  <div data-module="search-tracker">
+    {{ super() }}
+  </div>
+{% endblock %}
+
 {% block bodyStart %}
   {% call cookieBanner({
     category: "analytics"
@@ -18,14 +24,10 @@
   {% js %}
     window.GDS_CONSENT_COOKIE_VERSION = 1;
 
+    initialiseAnalytics()    
+
     createAll(CookieBanner)
     createAll(CookiesPage)
-
-    // Check for consent before initialising analytics
-    const userConsent = getConsentCookie()
-    if (userConsent && isValidConsentCookie(userConsent) && userConsent.analytics) {
-      loadAnalytics()
-    }
   {% endjs %}
 
   <script type="module" src="{% getBundleFileUrl 'js' %}"></script>

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -35,7 +35,7 @@ export default function(eleventyConfig) {
         esbuild.buildSync({
           entryPoints: ['./tmp/index.mjs'],
           outfile: './tmp/out.js',
-          minify: true,
+          minify: process.env.ELEVENTY_RUN_MODE == 'build',
           bundle: true,
         })
         return fs.readFileSync('./tmp/out.js', 'utf8')

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "govuk-content-publishing-guidance",
   "type": "module",
   "engines": {
-    "node": ">=22.11.0 <23",
-    "npm": ">=10.1.0 <11"
+    "node": ">=22.11.0 <23"
   },
   "scripts": {
     "start": "npx @11ty/eleventy --serve",


### PR DESCRIPTION
## What

Adds search tracking to GOV.UK Content Publishing Guidance. When the user types into the `input` or clicks a result, an event will be added to the `dataLayer` (if the user has accepted cookies).

- Move initialisation code for analytics to `initialiseAnalytics` function
- Add `SearchTracker` based on the existing search tracking code from the [Design System website](https://github.com/alphagov/govuk-design-system)
  - Add required functions from `analytics.mjs` from the [Design System website](https://github.com/alphagov/govuk-design-system)
  - Initialise the `SearchTracker` if user changes the cookie acceptance state to allow tracking

## Why

Requested by Publishing Team PAs to understand how users utilise the GOV.UK Content Publishing Guidance.

