### PR TITLE
Remove references to `govuk-frontend`

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,5 +1,4 @@
 import { govukEleventyPlugin } from '@x-govuk/govuk-eleventy-plugin';
-import Nunjucks from "nunjucks";
 import * as esbuild from 'esbuild'
 import * as fs from 'fs';
 import * as path from 'path';
@@ -44,12 +43,6 @@ export default function(eleventyConfig) {
     hoist: true,
     bundleExportKey: "bundle",
   });
-
-  let nunjucksEnvironment = new Nunjucks.Environment(
-    new Nunjucks.FileSystemLoader("node_modules/govuk-frontend/dist")
-  );
-
-  eleventyConfig.setLibrary("njk", nunjucksEnvironment);
 
   // Register the plugin
   eleventyConfig.addPlugin(govukEleventyPlugin, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,10 @@
       "dependencies": {
         "@11ty/eleventy": "^3.1.2",
         "@x-govuk/govuk-eleventy-plugin": "^7.2.1",
-        "esbuild": "^0.25.9",
-        "govuk-frontend": "^5.11.2",
-        "nunjucks": "^3.2.4"
+        "esbuild": "^0.25.9"
       },
       "engines": {
-        "node": ">=22.11.0 <23",
-        "npm": ">=10.1.0 <11"
+        "node": ">=22.11.0 <23"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
   "dependencies": {
     "@11ty/eleventy": "^3.1.2",
     "@x-govuk/govuk-eleventy-plugin": "^7.2.1",
-    "esbuild": "^0.25.9",
-    "govuk-frontend": "^5.11.2",
-    "nunjucks": "^3.2.4"
+    "esbuild": "^0.25.9"
   }
 }


### PR DESCRIPTION
## What

Remove extra references to `govuk-frontend`

## Why

These are not needed as `govuk-frontend` is already included in `@x-govuk/govuk-eleventy-plugin`. We also don't need to include the Nunjucks environment loader as this is also implemented by the `govuk-eleventy-plugin`.