### PR TITLE
Add `page_view` tracking [WHIT-2091]

### DIFF
--- a/_includes/javascripts/analytics.mjs
+++ b/_includes/javascripts/analytics.mjs
@@ -67,20 +67,3 @@ export function cookiesAccepted() {
 
   return userConsent && isValidConsentCookie(userConsent) && userConsent.analytics
 }
-
-// https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
-// to get the same event structure as used on GOV.UK, sadly not an importable
-// module so need to hardcode this copy-and-paste (and update it if changes) :(
-export const ecommerceSchema = {
-  event: null,
-  search_results: {
-    event_name: null,
-    term: null,
-    sort: null,
-    results: null,
-    ecommerce: {
-      items: null
-    }
-  },
-  event_data: null
-}

--- a/_includes/javascripts/application.mjs
+++ b/_includes/javascripts/application.mjs
@@ -1,9 +1,10 @@
-import { loadAnalytics, cookiesAccepted } from './analytics.mjs';
+import { loadAnalytics, cookiesAccepted } from './analytics.mjs'
 import { getConsentCookie, isValidConsentCookie } from './cookie-functions.mjs'
-import CookieBanner from './cookie-banner.mjs';
-import CookiesPage from './cookies-page.mjs';
-import { createAll } from 'govuk-frontend';
-import SearchTracker from './search-tracker.mjs';
+import CookieBanner from './cookie-banner.mjs'
+import CookiesPage from './cookies-page.mjs'
+import { createAll } from 'govuk-frontend'
+import SearchTracker from './search-tracker.mjs'
+import PageViewTracker from './page-view-tracker.mjs'
 
 const initialiseAnalytics = () => {
   if (cookiesAccepted()) {
@@ -11,4 +12,5 @@ const initialiseAnalytics = () => {
   }
 
   createAll(SearchTracker)
+  createAll(PageViewTracker)
 }

--- a/_includes/javascripts/page-view-tracker.mjs
+++ b/_includes/javascripts/page-view-tracker.mjs
@@ -1,0 +1,136 @@
+// https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-page-views.js
+// to get the same page view tracking as used on GOV.UK, sadly not an importable
+// module so need to hardcode this copy-and-paste (and update it if changes) :(
+import { Component } from 'govuk-frontend'
+import { cookiesAccepted, addToDataLayer, stripPossiblePII } from './analytics.mjs'
+
+class PageViewTracker extends Component {
+  static moduleName = 'page-view-tracker'
+
+  static checkSupport() {
+    super.checkSupport()
+
+    if (!cookiesAccepted()) {
+      throw Error('Cancelled initialisation as cookies not accepted')
+    }
+  }
+
+  constructor($root) {
+    super($root) 
+
+    const event = {
+      event: 'page_view',
+      page_view: {
+        location: this.getLocation(),
+        /* If the init() function receives a referrer parameter, this indicates that it has been called as a part of an AJAX request and
+        this.getReferrer() will not return the correct value. Therefore we need to rely on the referrer parameter. */
+        title: this.getTitle(),
+        status_code: this.getStatusCode(),
+        viewport_size: this.getViewPort(),
+        rendering_app: this.getMetaContent('rendering-app'),
+        language: this.getLanguage(),
+      }
+    }
+
+    addToDataLayer(event)
+  }
+
+  getBasePath () {
+    return this.getMetaContent('ga4-base-path')
+  }
+
+  getCanonicalHref () {
+    var link = document.querySelector('link[rel=canonical]')
+
+    if (link) {
+      return link.href
+    }
+
+    var basePath = this.getBasePath()
+
+    if (basePath) {
+      return window.location.origin + basePath // e.g. https://www.gov.uk + /browse
+    }
+  }
+
+  getLocation () {
+    // We don't want to remove dates on search pages.
+    return stripPossiblePII(this.stripGaParam(document.location.href))
+  }
+
+  getQueryString () {
+    var queryString = window.GOVUK.analyticsGa4.core.trackFunctions.getSearch()
+    if (queryString) {
+      // We don't want to remove dates on search pages.
+      queryString = this.stripGaParam(queryString)
+      queryString = stripPossiblePII(queryString)
+      queryString = queryString.substring(1) // removes the '?' character from the start.
+      return queryString
+    }
+  }
+
+  // remove GA parameters of the form _ga=2320.021-012302 or _gl=02.10320.01230-123
+  stripGaParam (str) {
+    str = str.replace(/(_ga=[0-9.-]+)/g, '_ga=[id]')
+    str = str.replace(/(_gl=[a-zA-Z0-9._\-*]+)/g, '_gl=[id]')
+    return str
+  }
+
+  getTitle () {
+    return stripPossiblePII(document.title)
+  }
+
+  // window.httpStatusCode is set in the source of the error page in static
+  // https://github.com/alphagov/static/blob/1c734451f2dd6fc0c7e80beccbdcbfa5aaffd0e4/app/views/root/_error_page.html.erb#L41-L43
+  getStatusCode () {
+    if (window.httpStatusCode) {
+      return window.httpStatusCode.toString()
+    } else {
+      return '200'
+    }
+  }
+
+  getViewPort () {
+    var vw = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0)
+    var vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
+    return vw + 'x' + vh
+  }
+
+  getMetaContent (name) {
+    var tag = document.querySelector('meta[name="govuk:' + name + '"]')
+    if (tag) {
+      var contentAttribute = tag.getAttribute('content')
+      if (contentAttribute === '') {
+        return undefined
+      }
+      return contentAttribute
+    } else {
+      return this.nullValue
+    }
+  }
+
+  getLanguage () {
+    var content = document.getElementById('content')
+    var html = document.querySelector('html')
+    if (content) {
+      var contentLanguage = content.getAttribute('lang')
+      if (contentLanguage) {
+        return contentLanguage
+      }
+    }
+    // html.getAttribute('lang') is untested - Jasmine would not allow lang to be set on <html>.
+    return html.getAttribute('lang') || this.nullValue
+  }
+
+  // return only the date from given timestamps of the form
+  // 2022-03-28T19:11:00.000+00:00
+  stripTimeFrom (value) {
+    if (value !== undefined) {
+      return value.split('T')[0]
+    } else {
+      return this.nullValue
+    }
+  }
+}
+
+export default PageViewTracker

--- a/_includes/javascripts/schemas.mjs
+++ b/_includes/javascripts/schemas.mjs
@@ -1,0 +1,94 @@
+// https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-schemas.js
+// to get the same event structure as used on GOV.UK, sadly not an importable
+// module so need to hardcode this copy-and-paste (and update it if changes) :(
+class Schemas {
+  static eventSchema = {
+    event: undefined,
+    event_data: {
+      event_name: undefined,
+      type: undefined,
+      url: undefined,
+      text: undefined,
+      text_2: undefined,
+      text_3: undefined,
+      text_4: undefined,
+      text_5: undefined,
+      index: {
+        index_link: undefined,
+        index_section: undefined,
+        index_section_count: undefined
+      },
+      index_total: undefined,
+      section: undefined,
+      action: undefined,
+      external: undefined,
+      method: undefined,
+      link_domain: undefined,
+      tool_name: undefined,
+      percent_scrolled: undefined,
+      video_current_time: undefined,
+      length: undefined,
+      video_percent: undefined,
+      autocomplete_input: undefined,
+      autocomplete_suggestions: undefined,
+      content_id: undefined,
+      user_id: undefined
+    }
+  }
+
+  static ecommerceSchema = {
+    event: undefined,
+    search_results: {
+      event_name: undefined,
+      term: undefined,
+      sort: undefined,
+      results: undefined,
+      ecommerce: {
+        items: []
+      }
+    },
+    event_data: {
+      external: true
+    }
+  }
+
+  // merge allowed data attributes into the event schema
+  static mergeProperties = function (data, eventAttribute, schema = this.eventSchema) {
+    schema.event = eventAttribute
+
+    for (var property in data) {
+      // some passed data might be undefined, don't want it to overwrite e.g. the index sub parameters
+      if (data[property] !== undefined) {
+        schema[eventAttribute] = this.addToObject(schema[eventAttribute], property, data[property])
+      }
+    }
+    return schema
+  }
+
+  static isAnObject = function (item) {
+    if (typeof item === 'object' && !Array.isArray(item) && item !== null) {
+      return true
+    }
+  }
+
+  // given an object and a key, insert a value into object[key] if it exists
+  static addToObject = function (obj, key, value) {
+    if (key in obj) {
+      obj[key] = value // ensure is a string
+      return obj
+    } else {
+      // check for one level of nesting in the object
+      for (var property in obj) {
+        if (this.isAnObject(obj[property])) {
+          if (key in obj[property]) {
+            obj[property][key] = value + '' // ensure is a string
+            return obj
+          }
+        }
+      }
+    }
+    return obj
+  }  
+}
+
+export default Schemas

--- a/_includes/javascripts/search-tracker.mjs
+++ b/_includes/javascripts/search-tracker.mjs
@@ -1,5 +1,6 @@
 import { Component } from 'govuk-frontend'
-import { cookiesAccepted, addToDataLayer, stripPossiblePII, ecommerceSchema } from './analytics.mjs'
+import { cookiesAccepted, addToDataLayer, stripPossiblePII } from './analytics.mjs'
+import Schemas from './schemas.mjs'
 
 class SearchTracker extends Component {
   static checkSupport() {
@@ -25,7 +26,7 @@ class SearchTracker extends Component {
     return results.map((searchResult, index) => ({
       item_name: searchResult.childNodes[0].nodeValue,
       item_list_name,
-      index
+      index: `${index}`,
     }))
   }
 
@@ -67,25 +68,21 @@ class SearchTracker extends Component {
   // based on the search tracking from alphagov#govuk-design-system
   // https://github.com/alphagov/govuk-design-system/blob/main/src/javascripts/components/search.tracking.mjs
   trackSearchInteraction(searchTerm, searchResults, clickedItem) {
-    const data = { ...ecommerceSchema }
-
     if ('DO_NOT_TRACK_ENABLED' in window && window.DO_NOT_TRACK_ENABLED) {
       return
     }
 
     const items = clickedItem ? [searchResults.find(({ item_name }) => clickedItem == item_name)] : searchResults
 
-    data.event = 'search_results'
-    data.event_data = { external: false }
-    data.search_results = {
+    const event = Schemas.mergeProperties({
       event_name: clickedItem ? 'select_item' : 'view_item_list',
       results: searchResults.length,
       term: stripPossiblePII(searchTerm),
       ecommerce: { items }
-    }
+    }, 'search_results', Schemas.ecommerceSchema)
 
     addToDataLayer({ search_results: { ecommerce: null } })
-    addToDataLayer(data)
+    addToDataLayer(event)
   }
 }
 

--- a/_includes/layouts/main.njk
+++ b/_includes/layouts/main.njk
@@ -10,6 +10,7 @@
 {% endblock %}
 
 {% block bodyStart %}
+  <div data-module="page-view-tracker"></div>
   {% call cookieBanner({
     category: "analytics"
   }) %}{% endcall %}
@@ -36,4 +37,5 @@
 {% block head %}
   {{ super() }}
   <meta name="robots" content="noindex, nofollow">
+  <meta name="govuk:rendering-app" content="govuk-content-publishing-guidance">
 {% endblock %}


### PR DESCRIPTION
## What

Track page views on Content Publishing Guidance.

### Technical Details

Needed to add the JS from GOV.UK Publishing Components for `page_view` tracking, as the original implementation for tracking page views on the Design System website uses automatic enhanced measurement (which we don't use on GOV.UK).

## Why

Requested by Publishing PA team.