### PR TITLE
Use `innerText` for `item_name` in search tracking [WHIT-2773]

### DIFF
--- a/_includes/javascripts/search-tracker.mjs
+++ b/_includes/javascripts/search-tracker.mjs
@@ -25,7 +25,7 @@ class SearchTracker extends Component {
 
   formatResults (item_list_name, results) {
     return results.map((searchResult, index) => ({
-      item_name: searchResult.childNodes[0].nodeValue,
+      item_name: searchResult.childNodes[0].innerText,
       item_list_name,
       index: `${index}`,
     }))
@@ -60,7 +60,7 @@ class SearchTracker extends Component {
     if (target.closest(".app-search__option")) {
       const searchTerm = this.siteSearch.querySelector('input').value
       const searchResults = this.siteSearch.querySelectorAll('#app-search__input__listbox li')
-      this.trackSearchInteraction(searchTerm, this.formatResults(searchTerm, [...searchResults]), target.childNodes[0].nodeValue)
+      this.trackSearchInteraction(searchTerm, this.formatResults(searchTerm, [...searchResults]), target.childNodes[0].innerText)
     }
   }
 


### PR DESCRIPTION
## What

Change calls to `nodeValue` to `innerText` in `search-tracker.mjs`

## Why

Reflects new structure of the list rendered by site search. This will ensure the correct item name is assigned to each item in the fired event. Before it was returning `null` for `item_name`. 
