### PR TITLE
Updated the service navigation header + added the topic 'publishing during national events'

### DIFF
--- a/app/publishing-national-events/general-elections/index.md
+++ b/app/publishing-national-events/general-elections/index.md
@@ -1,0 +1,54 @@
+---
+layout: landing-page
+sectionKey: Publishing during national events
+eleventyNavigation:
+  parent: Publishing during national events
+  order: 1
+title: General elections
+description: Understand the process for publishing on GOV.UK in the build up to a general election.
+lastUpdated:
+---
+
+During the pre-election period for a general election, there are restrictions on what you can publish on GOV.UK.
+
+Organisations using GOV.UK will be told when the pre-election period has started and ended.
+
+If you’re not sure whether the government is in the pre-election period, ask your GOV.UK lead.
+
+> [!NOTE]
+> There will be different guidance for pre-election periods before other types of elections, like local elections. Read the [pre-election guidance for civil servants](https://www.gov.uk/government/publications/election-guidance-for-civil-servants) for more information.
+
+## Publishing content
+
+It’s up to your organisation to decide whether content should be published, based on the [pre-election guidance for civil servants](https://www.gov.uk//government/publications/election-guidance-for-civil-servants).
+
+Check with a managing editor if something can be published. If they’re not sure, they should check with a senior member of your communications team. 
+
+Do not unpublish or withdraw content that was on GOV.UK before the pre-election period started.
+
+However, you can sometimes:
+
++ unpublish content published by mistake
++ unpublish and redirect pages when you’re merging content
++ withdraw content that is no longer current and has been replaced by something new
+
+In these cases, check with a director in your department.
+
+### Asking for updates to mainstream content
+
+You can [ask the Government Digital Service (GDS)](LINK) to publish small, factual changes during the pre-election period. That could include updates to:
+
++ change an address or phone number
++ fix something that’s stopping users completing a task
+
+If you want to publish bigger changes during the pre-election period, get approval from a director in your department. Confirm that you’ve done this when you ask GDS.
+
+## Preparing for history mode
+
+If the government changes after a general election, [history mode](LINK) could be activated.
+
+If you’re in one of the organisations that could be affected by history mode, you’ll be contacted by GDS.
+
+They’ll tell you how to audit your content that might go into history mode. You can choose which content you would allow to go into history mode.
+
+*[GDS]: Government Digital Service

--- a/app/publishing-national-events/index.md
+++ b/app/publishing-national-events/index.md
@@ -1,0 +1,15 @@
+---
+layout: landing-page
+sectionKey: Publishing during national events
+title: Publishing during national events
+description: Learn the processes for publishing on GOV.UK during general elections, Bridge events or national emergencies.
+lastUpdated:
+---
+
+This section will help you understand the special rules around publishing during significant national events.
+
+That includes:
+
+- [general elections](/publishing-national-events/general-elections/)
+- [royal deaths](/publishing-national-events/royal-deaths/), also known as ‘bridge events’
+- [national emergencies](/publishing-national-events/national-emergencies/)

--- a/app/publishing-national-events/national-emergencies/index.md
+++ b/app/publishing-national-events/national-emergencies/index.md
@@ -1,0 +1,142 @@
+---
+layout: landing-page
+sectionKey: Publishing during national events
+eleventyNavigation:
+  parent: Publishing during national events
+  order: 3
+title: National emergencies
+description: Understand the process for publishing on GOV.UK during a national emergency.
+lastUpdated:
+---
+The government will use GOV.UK to publish information for the public in the event of a national emergency.
+
+## Who is involved
+
+A lead agency will co-ordinate publishing. The Civil Contingencies Secretariat decides which agency this is.
+
+The lead agency must make sure that:
+
++ GOV.UK provides a single source of government information on the emergency
++ there is a high quality user journey between information published by different agencies responding to the emergency
+
+The Cabinet Office Briefing Room (COBR) is also likely to be involved.
+
+The Government Digital Service (GDS) can provide emergency support. If needed, they can put the GOV.UK homepage into national emergency mode.
+
+## What to do
+
+The lead agency should nominate a co-ordinator - for example, the head of its digital team.
+
+The co-ordinator should then work through the following steps:
+
+1. Create a destination page on GOV.UK.
+2. Contact GDS to deploy the GOV.UK ‘national emergency’ homepage (if needed).
+3. Organise further publishing with other agencies.
+
+## Step 1: Create a destination page on GOV.UK
+
+The government will promote a single page on GOV.UK as the destination for users who need information about the emergency.
+
+It should start with important information for the public, and then link out to more detailed information. The [Woolwich newsroom article](/government/news/woolwich-incident-government-response) is a good example of this.
+
+A link to the destination page should be given to the news media.
+
+### How to publish the page
+
+The co-ordinator from the lead agency needs to publish the page in Whitehall Publisher.
+
+Typically the page will use the [news article type](LINK), but this is flexible. For example, a co-ordinator could use:
+
+- a [topical event page](LINK) (this requires GDS approval)
+- a [travel advice page](LINK), in the case of an overseas crisis
+- an existing guide, in the case of a farming crisis
+
+The page’s title should include keywords specific to the incident, but be broad enough to allow for updates, for example:
+
++ Woolwich incident: government response
++ Woolwich incident: government updates
++ Woolwich incident: government information and advice
+
+The new page should go live straight away once published.
+
+### Updating the page
+
+The page should be updated frequently as the emergency situation changes.
+
+Make sure the page does not become cluttered. When you add new information, check the page is still well-organised and users can find what they need.
+
+For significant changes, change notes must be used to describe how the page has changed. The updated page will then appear in GOV.UK latest news feeds and email alerts.
+
+Updates should go live within 5 minutes of publishing.
+
+## Step 2: Contact GDS to deploy the GOV.UK ‘national emergency’ homepage
+
+Only do this if the emergency poses an immediate risk to life and demands immediate mass public action.
+
+The co-ordinator in the lead agency needs to call the GDS emergency phone number.
+
+They can find the phone number under ‘Update GOV.UK following a national emergency’ on the [emergency contact details page](https://support.publishing.service.gov.uk/emergency-contact-details). They need a [Signon account](LINK) to access that page.
+
+GDS will confirm their identity and verify that the emergency is of an appropriate scale to deploy the GOV.UK emergency homepage.
+
+It takes 30 minutes to deploy the emergency homepage.
+
+The emergency homepage features a prominent red banner. The banner also appears in a less prominent form at the top of every page on GOV.UK.
+
+### What goes on the banner
+
+The co-ordinator will need to provide:
+
++ wording for the banner
++ a link to the destination page created in Step 1
+
+Follow the banner wording guidance. GDS can provide out-of-hours content design support. The emergency contact will be able to put the co-ordinator in touch.
+
+### Banner wording
+
+The banner is made up of 3 parts:
+
++ headline - 30 characters or less
++ body text - 2 sentences or less, including any important, practical messages for users
++ link - an optional link to the destination page
+
+Strip any formatting (such as bold text) from the banner wording.
+
+Content for the banner should be brief and clear. Users are likely to:
+
++ be in stressful situations
++ need to take immediate action
++ read the banner on a mobile phone
+
+Because the banner will display on every page of GOV.UK, it will also affect how usable the whole site is.
+
+Examples:
+
+> [!NOTE]
+> Headline: London security incident
+> Body text: There has been a major incident in central London. Public transport is suspended in Zone 1.
+> Link: Find out about the government’s response to the incident.
+
+> [!NOTE]
+> Headline: Flooding in south west England
+> Body text: There are severe floods and storms across the south west of England. The M5 motorway is closed.
+> Link: Find out about the government’s response to the flooding.
+
+## Step 3: Organise further publishing with other agencies
+
+As soon as possible after a severe crisis has been identified, the lead agency and a member of the GOV.UK programme team should arrange a conference call. The conference call will include representatives from the digital teams in relevant departments.
+
+GDS will choose a single content-related point of contact to help with any further publishing.
+
+This conference call, and follow-up calls and documentation, will establish:
+
++ promotion of the agreed single destination from departmental homepages and social media
++ content responsibilities of different departments
+
+If the emergency is severe, GDS can also help with analysis of:
+
++ search terms used by citizens, to ensure content is optimised
++ performance of destination content (bounce rates, user journeys)
+
+*[COBR]: Cabinet Office Briefing Room
+*[GDS]: Government Digital Service

--- a/app/publishing-national-events/royal-deaths/index.md
+++ b/app/publishing-national-events/royal-deaths/index.md
@@ -1,0 +1,83 @@
+---
+layout: landing-page
+sectionKey: Publishing during national events
+eleventyNavigation:
+  parent: Publishing during national events
+  order: 2
+title: Royal deaths ('bridges')
+description: Understand the process for publishing on GOV.UK when a member of the royal family has died.
+lastUpdated:
+---
+
+Royal deaths (also known as ‘bridges’ or ‘bridge events’) can affect publishing.
+
+You’ll be told by the Government Digital Service (GDS) if a bridge event has begun. They’ll send messages:
+
+- on the [content community Basecamp](link to guidance on joining Basecamp) 
+- through emails to your GOV.UK lead
+
+## Publishing on GOV.UK
+
+Following a royal death, you’ll be told if there’s a freeze on publishing content on GOV.UK.
+
+If there’s a freeze, content that cannot be published includes:
+
+- press releases and news stories
+- policy documents
+- transparency data
+- any items that had previously been on the Number 10 planning grid
+- updates to campaign sites or new campaigns
+- minor updates (for example, correcting typos)
+
+If you have clearance from your permanent secretary and Number 10, you can still publish:
+
+- critical factual updates (for example, medical safety alerts)
+- legally-required content (for example, national statistics)
+- other necessary factual updates (for example, fixing broken links or critical service updates)
+
+You should cancel any scheduled publishing that does not meet these conditions.
+
+The freeze would also apply to digital marketing (except essential campaigns).
+
+GDS will tell you when regular publishing can resume.
+
+Follow civil service guidance on the national mourning period. If you need more information or clarification on what can be published during a freeze, contact your director of communications and permanent secretary.
+
+## Publishing banners on non-GOV.UK sites
+
+A sitewide banner will be deployed on GOV.UK during a bridge event. Whether you can deploy a similar banner on a non-GOV.UK site depends on the type of site.
+
+### Services
+
+Services on service.gov.uk should not deploy a banner.
+
+### Campaign sites
+
+Campaign sites on campaign.gov.uk should not deploy a banner.
+
+### Other non-GOV.UK sites
+
+Other non-GOV.UK sites (those with an exemption) do not have to deploy a banner, but can choose to do so.
+
+If non-GOV.UK sites do want to deploy a banner, it should:
+
+- be consistent with the site’s design styles, such as typography specifications
+- follow responsive web design principles (for example, the banner should adjust to screen size allowing it to be viewed on mobile and tablet devices)
+- not use modal pop-up windows (for example, a pop-up window over content)
+- not use images unless appropriate licensing has been procured
+- match the site’s width
+- meet [government accessibility requirements](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag) (for example, colour contrast, font size, link focus states, and making sure the design works with screen readers)
+
+The banner should be displayed for all of the period of national mourning.
+
+The banner specifications for desktop are:
+
+- Background colour: Black (#0b0c0c)
+- Width: full site width
+- Content area width: 960 pixels
+- Text colour: White (#ffffff)                                                                                    
+- Link style: White underline
+- Title size on homepage: 48 pixels
+- Title size on sitewide content (not homepage): 24 pixels
+- Summary text size: 19 pixels
+- Link text size: 19 pixels

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -66,6 +66,10 @@ export default function(eleventyConfig) {
             text: "Writing to GOV.UK standards",
             href: "/writing-to-gov-uk-standards"
         },
+        {   
+            text: "Publishing during national events",
+            href: "/publishing-national-events"
+        },
       ]
     },
     footer: {


### PR DESCRIPTION
Adding a new topic area, 'publishing during national events'. This topic only has 3 pages in it, so each is formatted as a sub topic page (ie a folder with an index page). Eleventy config file updated to add the new topic to the service navigation menu. 