### PR TITLE
Add metatag for Google Search Console verification

### DIFF
--- a/_includes/layouts/main.njk
+++ b/_includes/layouts/main.njk
@@ -36,6 +36,7 @@
 {% endblock %}
 {% block head %}
   {{ super() }}
+  <meta name="google-site-verification" content="T789KqsmfvlTlaW2rvm5QJQBRYYL8yePTZWMJxMhIfo"/>
   <meta name="robots" content="noindex, nofollow">
   <meta name="govuk:rendering-app" content="govuk-content-publishing-guidance">
 {% endblock %}


### PR DESCRIPTION
## What

Add metatag for Google Search Console verification.

## Why

The way that Google Tag Manager script is added (after a check to see if user has accepted cookies) means that we need to use this method to verify the website.