### PR TITLE
Change Node version to 24

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -14,7 +14,7 @@ export default function(eleventyConfig) {
             let entries = fs.readdirSync(src, { recursive: true, withFileTypes: true })
 
             for (let entry of entries) {
-                let srcPath = path.join(entry.path, entry.name);
+                let srcPath = path.join(entry.parentPath, entry.name);
                 let destPath = srcPath.replace(src, dest);
                 let destDir = path.dirname(destPath);
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "govuk-content-publishing-guidance",
   "type": "module",
   "engines": {
-    "node": ">=22.11.0 <23"
+    "node": ">=24"
   },
   "scripts": {
     "start": "npx @11ty/eleventy --serve",


### PR DESCRIPTION
## What 

- changed the version of Node to 24
- updated `entry.path` to `entry.parentPath`

## Why

Causing an issue on Github Codespaces because in an update to Node the attributes of the entry objects returned by `readdirSync` have been renamed. The Node version has been changed so that this does not cause an error in local development. This addresses the issue raised in https://github.com/alphagov/govuk-content-publishing-guidance/pull/68.