### PR TITLE
Change search index

### DIFF
--- a/_includes/layouts/search-index.njk
+++ b/_includes/layouts/search-index.njk
@@ -1,0 +1,18 @@
+[{% for item in collections.sitemap %}
+{% if item.data.layout == "style-guide" %}
+  {
+    "title": {{ item.data.title | default("") | dump | safe }},
+    {% if item.data.description %}"description": {{ item.data.description | dump | safe }},{% endif %}
+    {% if item.data.eleventyNavigation.parent and item.data.eleventyNavigation.parent != item.data.options.homeKey %}"section": {{ item.data.eleventyNavigation.parent | dump | safe }},{% endif %}
+    "tokens": {{ item.templateContent | tokenize | default([]) | dump | safe }},
+    "url": {{ item.url | canonicalUrl | pretty | default("") | dump | safe }}
+  }{% if not loop.last %},{% endif %}
+{% else %}
+  {
+    "title": {{ item.data.title | default("") | dump | safe }},
+    {% if item.data.description %}"description": {{ item.data.description | dump | safe }},{% endif %}
+    {% if item.data.eleventyNavigation.parent and item.data.eleventyNavigation.parent != item.data.options.homeKey %}"section": {{ item.data.eleventyNavigation.parent | dump | safe }},{% endif %}
+    "url": {{ item.url | canonicalUrl | pretty | default("") | dump | safe }}
+  }{% if not loop.last %},{% endif %}
+{% endif %}
+{% endfor %}]

--- a/app/search.json.njk
+++ b/app/search.json.njk
@@ -1,0 +1,5 @@
+---
+eleventyExcludeFromCollections: true
+layout: search-index
+permalink: /search.json
+---

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -55,7 +55,7 @@ export default function(eleventyConfig) {
     header: {
       productName: 'Content and publishing guidance',
       search: {
-        indexPath: '/search-index.json',
+        indexPath: '/search.json',
         sitemapPath: '/sitemap',
         label: "Search guidance"
       }
@@ -114,7 +114,7 @@ export default function(eleventyConfig) {
       }
     },
     templates: {
-      searchIndex: true,
+      searchIndex: false,
     }
   });
   eleventyConfig.addPreprocessor("macro-inject", ".njk,.md", (data, content) => {


### PR DESCRIPTION
This pull request:

- reintroduces a specific search index layout and custom index
- changes the config of the search index for the entire site

The search index only includes title, description, section and URL unless the page uses the `style-guide` layout. If it uses the `style-guide` layout, it also includes the page content.