### PR TITLE
Update publish, update and retire topic key, title and parents

### DIFF
--- a/_includes/layouts/landing-page.njk
+++ b/_includes/layouts/landing-page.njk
@@ -16,6 +16,7 @@
 
       {{ appProseScope(content) if content }}
       {% include "layouts/shared/last-updated.njk" %}
+      {% include "layouts/shared/sharing-links.njk" %}
       {% include "layouts/shared/related.njk" %}
     </div>
   </div>

--- a/_includes/layouts/shared/document-header.njk
+++ b/_includes/layouts/shared/document-header.njk
@@ -2,7 +2,13 @@
       {% if title %}
   <header class="doc-header">
     {% if eleventyNavigation.parent != options.homeKey %}
-      <span class="govuk-caption-xl">{% if eleventyNavigation.parent != options.homeKey %}{{ eleventyNavigation.parent }}{% endif %}</span>
+      <span class="govuk-caption-xl">
+      {% if eleventyNavigation.parentTitle %}
+        {{ eleventyNavigation.parentTitle }}
+      {% else %}
+        {{ eleventyNavigation.parent }}
+      {% endif %}
+      </span>
     {% endif %}
     <h1 class="doc-header__title govuk-heading-xl">
       {{ title | smart }}

--- a/_includes/layouts/shared/phase-banner.njk
+++ b/_includes/layouts/shared/phase-banner.njk
@@ -4,7 +4,7 @@
           Beta
         </strong>
         <span class="govuk-phase-banner__text">
-        Help improve the content and publishing guidance. <a href="https://surveys.publishing.service.gov.uk/s/5SR5IK/?current_page={{ page.url }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Give your feedback (opens in new tab)</a>.
+        Help improve the content and publishing guidance. <a href="https://surveys.publishing.service.gov.uk/s/give-feedback-content-publishing-guidance?current_page={{ page.url }}" class="govuk-link" rel="noreferrer noopener" target="_blank">Give your feedback (opens in new tab)</a>.
         </span>
       </p>
     </div>

--- a/_includes/layouts/shared/sharing-links.njk
+++ b/_includes/layouts/shared/sharing-links.njk
@@ -1,0 +1,36 @@
+<div class="share-links govuk-!-display-none-print" dir="ltr" title="Share this page">
+<h2 class="govuk-heading-s">Share this page</h2>
+    <p class="govuk-body-s">
+      The following links open in a new tab
+    </p>
+    <ul class="share-links__list">
+        <li class="share-links__list-item">
+          <a target="_blank" rel="noopener noreferrer external" class="govuk-link govuk-link--no-underline share-links__link" href="mailto:?body=https://guidance.publishing.service.gov.uk{{ page.url }}">
+            <span class="share-links__link-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 73.84 73.84" aria-hidden="true" focusable="false" width="0" height="0" class="share-links__svg">
+                  <path fill="currentColor" d="M36.92,0A36.92,36.92,0,1,0,73.84,36.92,36.92,36.92,0,0,0,36.92,0ZM58.37,21,36.92,39.45,15.47,21ZM11.65,23.66,26.27,36.23,11.65,49.9ZM15.1,52.83,29.7,39.18l7.22,6.21,7.22-6.21,14.6,13.65ZM62.19,49.9,47.57,36.23,62.19,23.66Z"></path>
+                </svg>            </span><span class="share-links__label">          <span class="govuk-visually-hidden">
+              Share by
+          </span>
+          Email
+          <span class="govuk-visually-hidden">
+            (opens in new tab)
+          </span>
+</span></a>
+        </li>
+        <li class="share-links__list-item">
+          <a target="_blank" rel="noopener noreferrer external" class="govuk-link govuk-link--no-underline share-links__link" href="https://teams.microsoft.com/share?href=https://guidance.publishing.service.gov.uk{{ page.url }}">
+            <span class="share-links__link-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 73.84 73.84" aria-hidden="true" focusable="false" width="0" height="0" class="share-links__svg">
+                  <path fill="currentColor" d="M36.92,0A36.92,36.92,0,1,0,73.84,36.92,36.92,36.92,0,0,0,36.92,0ZM56.3,48.27a1.42,1.42,0,0,1-1.42,1.42h-19v9.18l-9.18-9.18H19a1.43,1.43,0,0,1-1.43-1.43V20.52A1.43,1.43,0,0,1,19,19.09H54.88a1.43,1.43,0,0,1,1.42,1.42Z"></path>
+                </svg>            </span><span class="share-links__label">          <span class="govuk-visually-hidden">
+              Share on
+          </span>
+          Microsoft Teams
+          <span class="govuk-visually-hidden">
+            (opens in new tab)
+          </span>
+</span></a>
+        </li>
+    </ul>
+</div>

--- a/_includes/layouts/style-guide.njk
+++ b/_includes/layouts/style-guide.njk
@@ -51,6 +51,7 @@
     {{ appProseScope(content) if content }}
 </div>
 
+      {% include "layouts/shared/sharing-links.njk" %}
       {% include "layouts/shared/related.njk" %}
     </div>
   </div>

--- a/app/assets/styles.scss
+++ b/app/assets/styles.scss
@@ -59,3 +59,57 @@ abbr {
   display: block;
   overflow-x: auto;
 }
+
+.share-links__list {
+    list-style: none;
+    margin: 0;
+    padding: 0
+}
+
+.share-links__list-item {
+    box-sizing: border-box;
+    position: relative;
+    display: inline-block;
+    min-height: 30px;
+    padding-top: 5px;
+    padding-left: 40px;
+    padding-right: 10px;
+    margin-bottom: 10px;
+    font-size: 15px
+}
+
+.share-links__link {
+    margin-right: 30px;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 700;
+    font-size: 1rem;
+    line-height: 1.25
+}
+
+@media print {
+    .share-links__link {
+        font-family: sans-serif
+    }
+}
+
+@media print {
+    .share-links__link {
+        font-size: 14pt;
+        line-height: 1.2
+    }
+}
+
+.share-links__link-icon {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 30px;
+    height: 30px;
+    line-height: 30px
+}
+
+.share-links__svg {
+    width: 100%;
+    height: 100%
+}

--- a/app/publish-update-retire-content/choose-content-type/index.md
+++ b/app/publish-update-retire-content/choose-content-type/index.md
@@ -4,6 +4,7 @@ sectionKey: Publish update or retire content
 order: 1
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 title: Choose a content type
 description: Learn which content types to use for what you're publishing.
 lastUpdated:

--- a/app/publish-update-retire-content/corporate-information/index.md
+++ b/app/publish-update-retire-content/corporate-information/index.md
@@ -3,6 +3,7 @@ layout: landing-page
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 5
 title: Corporate information pages
 description: Learn how to publish, update or retire corporate information pages. 

--- a/app/publish-update-retire-content/index.md
+++ b/app/publish-update-retire-content/index.md
@@ -1,7 +1,10 @@
 ---
 layout: landing-page
-sectionKey: Publish update or retire content
 title: Publish, update or retire content
+sectionKey: Publish update or retire content
+eleventyNavigation:
+  title: "Publish, update or retire content"
+  key: Publish update or retire content
 description: Learn how to publish content to GOV.UK, change published content or withdraw or unpublish it.
 lastUpdated:
 ---

--- a/app/publish-update-retire-content/organisations-people/index.md
+++ b/app/publish-update-retire-content/organisations-people/index.md
@@ -3,6 +3,7 @@ layout: landing-page
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 4
 title: Organisations and people
 description: Learn how to publish, update or retire content types about government organisations or people. 

--- a/app/publish-update-retire-content/other-content-types/index.md
+++ b/app/publish-update-retire-content/other-content-types/index.md
@@ -3,6 +3,7 @@ layout: landing-page
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 3
 title: Other guidance content types
 description: Learn how to publish, update or retire content types that do not follow the same processes as 'standard' content types.

--- a/app/publish-update-retire-content/promotional-social/index.md
+++ b/app/publish-update-retire-content/promotional-social/index.md
@@ -3,6 +3,7 @@ layout: landing-page
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 6
 title: Promotional or social content types
 description: Learn how to publish, update or retire blogs, campaigns or topical events. 

--- a/app/publish-update-retire-content/standard-content-types/index.md
+++ b/app/publish-update-retire-content/standard-content-types/index.md
@@ -1,10 +1,11 @@
 ---
 layout: landing-page
+title: Standard content types
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 2
-title: Standard content types
 description: Learn how to follow the common processes for standard content types such as detailed guides and consultations.
 lastUpdated:
 ---


### PR DESCRIPTION
This pull request:

- adds a key and title to `eleventyNavigation` on the publish, update and retire topic
- adds a new `parentTitle` to sub-topic index pages for consistent naming of the topic
- updates the caption to include `eleventyNavigation.parentTitle`

This allows us to consistently show the topic title in breadcrumbs and captions on sub-topic pages