### PR TITLE
Update 'publish, update and retire content' topic key, title and parents

### DIFF
--- a/_includes/layouts/search-index.njk
+++ b/_includes/layouts/search-index.njk
@@ -11,7 +11,11 @@
   {
     "title": {{ item.data.title | default("") | dump | safe }},
     {% if item.data.description %}"description": {{ item.data.description | dump | safe }},{% endif %}
-    {% if item.data.eleventyNavigation.parent and item.data.eleventyNavigation.parent != item.data.options.homeKey %}"section": {{ item.data.eleventyNavigation.parent | dump | safe }},{% endif %}
+    {% if item.data.eleventyNavigation.parentTitle %}
+      {% if item.data.eleventyNavigation.parent and item.data.eleventyNavigation.parent != item.data.options.homeKey %}"section": {{ item.data.eleventyNavigation.parentTitle | dump | safe }},{% endif %}
+      {% else %}
+      {% if item.data.eleventyNavigation.parent and item.data.eleventyNavigation.parent != item.data.options.homeKey %}"section": {{ item.data.eleventyNavigation.parent | dump | safe }},{% endif %}
+    {% endif %}
     "url": {{ item.url | canonicalUrl | pretty | default("") | dump | safe }}
   }{% if not loop.last %},{% endif %}
 {% endif %}

--- a/_includes/layouts/shared/document-header.njk
+++ b/_includes/layouts/shared/document-header.njk
@@ -2,7 +2,13 @@
       {% if title %}
   <header class="doc-header">
     {% if eleventyNavigation.parent != options.homeKey %}
-      <span class="govuk-caption-xl">{% if eleventyNavigation.parent != options.homeKey %}{{ eleventyNavigation.parent }}{% endif %}</span>
+    <span class="govuk-caption-xl">
+      {% if eleventyNavigation.parentTitle %}
+        {{ eleventyNavigation.parentTitle }}
+      {% else %}
+        {{ eleventyNavigation.parent }}
+      {% endif %}
+    </span>
     {% endif %}
     <h1 class="doc-header__title govuk-heading-xl">
       {{ title | smart }}

--- a/app/publish-update-retire-content/choose-content-type/index.md
+++ b/app/publish-update-retire-content/choose-content-type/index.md
@@ -4,6 +4,7 @@ sectionKey: Publish update or retire content
 order: 1
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 title: Choose a content type
 description: Learn which content types to use for what you're publishing.
 lastUpdated:

--- a/app/publish-update-retire-content/corporate-information/index.md
+++ b/app/publish-update-retire-content/corporate-information/index.md
@@ -3,6 +3,7 @@ layout: landing-page
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 5
 title: Corporate information pages
 description: Learn how to publish, update or retire corporate information pages. 

--- a/app/publish-update-retire-content/index.md
+++ b/app/publish-update-retire-content/index.md
@@ -1,7 +1,10 @@
 ---
 layout: landing-page
-sectionKey: Publish update or retire content
 title: Publish, update or retire content
+sectionKey: Publish update or retire content
+eleventyNavigation:
+  title: "Publish, update or retire content"
+  key: Publish update or retire content
 description: Learn how to publish content to GOV.UK, change published content or withdraw or unpublish it.
 lastUpdated:
 ---

--- a/app/publish-update-retire-content/organisations-people/index.md
+++ b/app/publish-update-retire-content/organisations-people/index.md
@@ -3,6 +3,7 @@ layout: landing-page
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 4
 title: Organisations and people
 description: Learn how to publish, update or retire content types about government organisations or people. 

--- a/app/publish-update-retire-content/other-content-types/index.md
+++ b/app/publish-update-retire-content/other-content-types/index.md
@@ -3,6 +3,7 @@ layout: landing-page
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 3
 title: Other guidance content types
 description: Learn how to publish, update or retire content types that do not follow the same processes as 'standard' content types.

--- a/app/publish-update-retire-content/promotional-social/index.md
+++ b/app/publish-update-retire-content/promotional-social/index.md
@@ -3,6 +3,7 @@ layout: landing-page
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 6
 title: Promotional or social content types
 description: Learn how to publish, update or retire blogs, campaigns or topical events. 

--- a/app/publish-update-retire-content/standard-content-types/index.md
+++ b/app/publish-update-retire-content/standard-content-types/index.md
@@ -1,10 +1,11 @@
 ---
 layout: landing-page
+title: Standard content types
 sectionKey: Publish update or retire content
 eleventyNavigation:
   parent: Publish update or retire content
+  parentTitle: "Publish, update or retire content"
 order: 2
-title: Standard content types
 description: Learn how to follow the common processes for standard content types such as detailed guides and consultations.
 lastUpdated:
 ---


### PR DESCRIPTION
This pull request:

- adds a key and title to eleventyNavigation on the publish, update and retire topic
- adds a new parentTitle to sub-topic index pages for consistent naming of the topic
- updates the caption to include `eleventyNavigation.parentTitle`
- updates search index to include logic to support `eleventyNavigation.parentTitle`

This allows us to consistently show the topic title in breadcrumbs, captions and search on sub-topic pages