### PR TITLE
Michele content advice mentions

### DIFF
--- a/_includes/reusable-content/remove-history-mode.md
+++ b/_includes/reusable-content/remove-history-mode.md
@@ -1,2 +1,3 @@
-> [!NOTE]
-> If you select 'Create new edition' and you get a message telling you that the 'document is in history mode', you cannot update it without help from the Government Digital Service (GDS). [Ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you want to remove history mode.
+If you select 'Create new edition' and you get a message telling you that the 'document is in history mode', you cannot update it without help from the Government Digital Service (GDS). [Ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you want to remove history mode.
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.

--- a/_includes/reusable-content/update-url.md
+++ b/_includes/reusable-content/update-url.md
@@ -14,3 +14,5 @@ You can:
 4. [Unpublish the page](/publish-update-retire-content/standard-content-types/withdraw-unpublish-standard/) with the incorrect URL. When you unpublish it, you'll be able to set up a redirect to the new page.
 
 The change notes history will be lost if you do this. If you need to keep that history, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) and ask them to change the URL instead.
+
+You’ll need a Signon account with ‘content requesters’ permissions to contact GDS using the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.

--- a/app/accounts-support/get-content-advice/get-help-advice.md
+++ b/app/accounts-support/get-content-advice/get-help-advice.md
@@ -25,6 +25,8 @@ It may be a quick question about content you’re working on or a request for a 
   
 [Ask for advice from GDS](https://support.publishing.service.gov.uk/content_advice_request/new).
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 ## Support from across government
 
 As well as contacting GDS, you can get help from content colleagues across government. 

--- a/app/accounts-support/make-content-requests/ask-new-organisation.md
+++ b/app/accounts-support/make-content-requests/ask-new-organisation.md
@@ -77,6 +77,8 @@ GDS will expect a sub-organisation to have:
 
 Use the [content advice support form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request.
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice support form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 ## What happens after you make a request
 
 GDS will review your request. If your request is approved, GDS will create a new organisation page with the ‘coming soon’ status to allow you to [create, edit and add content to your organisation page](/publish-update-retire-content/organisations-people/organisations/) before it goes live.

--- a/app/accounts-support/make-content-requests/ask-short-url.md
+++ b/app/accounts-support/make-content-requests/ask-short-url.md
@@ -36,7 +36,9 @@ Submit your request at least 2 weeks before you need it. The Government Digital 
 
 Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-Include:
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
+Include in your request:
 
 * the reason you need a short URL
 * the content or page the short URL will link to

--- a/app/accounts-support/make-content-requests/ask-update-remove-related-links.md
+++ b/app/accounts-support/make-content-requests/ask-update-remove-related-links.md
@@ -25,6 +25,8 @@ You must include:
 
 Use the [content advice support form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request. 
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice support form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 Requests to update related links are reviewed on a case by case basis.
 
 *[GDS]: Government Digital Service 

--- a/app/publish-update-retire-content/organisations-people/groups.md
+++ b/app/publish-update-retire-content/organisations-people/groups.md
@@ -177,6 +177,8 @@ Good examples of closed groups include the:
 
 [Ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you want a new group page with the updated name.
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 When you have that approval, close the old group page and set up one with the new name.
 
 A good example of a group that has changed its name is the [Group Litigation Order (GLO) Compensation Scheme Advisory Board](https://www.gov.uk/government/groups/group-litigation-order-glo-compensation-scheme-advisory-board).

--- a/app/publish-update-retire-content/organisations-people/organisations.md
+++ b/app/publish-update-retire-content/organisations-people/organisations.md
@@ -434,7 +434,9 @@ There may be exceptions to the list of content types that should not be retagged
 
 If there is too much content for you to retag manually, you can [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) to do a bulk retag. 
 
-You’ll need to create and send over a new spreadsheet of the content that need retagging. Only include these columns in the spreadsheet, using these specific headings:
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
+For your request, you’ll need to create and send over a new spreadsheet of the content that need retagging. Only include these columns in the spreadsheet, using these specific headings:
 
 - ‘URL’ – this is the full URL of the content and not just the slug
 - ‘Lead organisations’ – list the slugs of the organisation pages that should be tagged as lead organisations on the content (including any closed organisations), separated by commas with no spaces such as `department-for-science-innovation-and-technology,government-digital-service`
@@ -456,5 +458,8 @@ You can also [ask GDS for help](https://support.publishing.service.gov.uk/conten
 If anyone is listed under ‘Our management’ on the organisation page, unassign them from their roles when you close the organisation. Read the [guidance about people and role pages](/publish-update-retire-content/organisations-people/people-roles) for help with that.
 
 If anyone is listed under ‘Our ministers’, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) before you update their information.
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 
 *[GDS]: Government Digital Service

--- a/app/publish-update-retire-content/organisations-people/people-roles.md
+++ b/app/publish-update-retire-content/organisations-people/people-roles.md
@@ -37,6 +37,8 @@ GDS will contact GOV.UK leads in ministerial departments to let them know what's
 
 If it's a change to only one or two ministerial appointments, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) to check if you can create and assign the new people and role pages yourself.
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 If you can make the changes yourself, ask the minister's private office and the Number 10 digital communications team for the details you can use.
 
 ### Other changes to existing ministerial pages
@@ -55,9 +57,13 @@ If it's a new junior ministerial role with a generic name like 'Minister of Stat
 
 If you want to make other changes, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval.
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
+
 ## Add or edit a people page
 
 If you’re adding a new minister, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval.
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
 
 >[!NOTE]
 >When adding or editing a people page, be aware that it will publish or update as soon as you select ‘Save’ – there’s no draft state or peer review.
@@ -91,6 +97,8 @@ For all biographies, do not include information about their personal life, for e
 ## Add or edit a role page
 
 If you’re adding or editing a ministerial role page, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval.
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
 
 >[!NOTE]
 >When adding or editing a role page, be aware that it will publish or update as soon as you select ‘Save’ or ‘Save and continue’ – there’s no draft state or peer review.
@@ -145,6 +153,8 @@ Do not change anything about the original role or assign it to anyone until it's
 
 If it’s an interim ministerial role, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) before making these changes.
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 ## Assign a role to a person
 
 >[!NOTE]
@@ -177,6 +187,8 @@ If there’s no replacement, you need to end their appointment:
 4. Add the end date and select ‘Save’.
 
 If it’s a ministerial role, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first before making any of these changes.
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
 
 ### Update the person’s biography
 

--- a/app/publish-update-retire-content/organisations-people/worldwide.md
+++ b/app/publish-update-retire-content/organisations-people/worldwide.md
@@ -29,6 +29,8 @@ The 2 types of pages are very similar and are updated in the same way.
 
 You can update an existing world location news page. If you want to add a new one, [ask the Government Digital Service (GDS) for help](https://support.publishing.service.gov.uk/content_advice_request/new).
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 ### Edit a world locations news page
 
 1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
@@ -313,6 +315,8 @@ There's a navigation page for each country and territory.
 
 - a new navigation page
 - to edit the title, sections or description of an existing page
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
  
 ### Tag content
 
@@ -341,5 +345,8 @@ You can also [ask GDS for help](/accounts-support/get-content-advice/get-help-ad
 * manuals
 * specialist finders
 * travel advice pages
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
  
 *[GDS]: Government Digital Service

--- a/app/publish-update-retire-content/other-content-types/manuals.md
+++ b/app/publish-update-retire-content/other-content-types/manuals.md
@@ -50,6 +50,8 @@ Their request for a new manual must show:
 
 [Contact GDS using the advice form](https://support.publishing.service.gov.uk/content_advice_request/new).
 
+Your GOV.UK lead or managing editor will need a Signon account with ‘content requesters’ permissions to access the advice form.
+
 ## Get access to Manuals Publisher
 
 You'll need access to [Manuals Publisher](https://manuals-publisher.publishing.service.gov.uk/manuals) to create or update manuals. 
@@ -130,11 +132,15 @@ Your manual will be automatically tagged to the same organisation as your Signon
 
 If you want to change the organisation or tag more organisations, [contact GDS using the advice form](https://support.publishing.service.gov.uk/content_advice_request/new).
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the advice form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 ## Tag to topic pages
 
 You can only tag the manual to topic pages once the first draft is published.
 
 You'll need to [contact GDS using the advice form](https://support.publishing.service.gov.uk/content_advice_request/new) and ask them to tag the manual for you.
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the advice form. Speak to your GOV.UK lead or managing editor if you want access to the form.
 
 ## Unpublish a manual
 
@@ -150,5 +156,8 @@ To unpublish sections of a manual:
 4. When you've done this for every relevant section, publish the draft.
 
 To unpublish the manual as a whole, [contact GDS using the advice form](https://support.publishing.service.gov.uk/content_advice_request/new) and explain why the manual needs to be unpublished.
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the advice form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 
 *[GDS]: Government Digital Service

--- a/app/writing-to-gov-uk-standards/help-users-prepare-change/index.md
+++ b/app/writing-to-gov-uk-standards/help-users-prepare-change/index.md
@@ -42,6 +42,8 @@ In exceptional cases, users might need reassurance in advance that something wil
 
 If you’re unsure, [ask for help from the Government Digital Service (GDS)](https://support.publishing.service.gov.uk/content_advice_request/new).
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 ## Review content that already exists
 
 Do a basic review of existing guidance content as soon as you know roughly what's changing. Do not wait until you have all the details.

--- a/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
@@ -32,6 +32,8 @@ Govsearch will not show content that's published using non-GOV.UK tools, includi
 
 [Ask the Government Digital Service (GDS) for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you would like to search this other content.
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 ### If you're only interested in Whitehall Publisher
 
 You can [use the Whitehall Publisher search tool](https://whitehall-admin.publishing.service.gov.uk/government/admin/editions) to look through content on Whitehall Publisher.
@@ -91,6 +93,8 @@ If the page is tagged to other organisations and not yours, contact their contac
 
 [Ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you need contact information for other content teams.
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
 ### If your content is on a 'mainstream' page
 
 Mainstream pages will not have 'government' or 'guidance' in the URL. They are maintained by the content team at GDS, with changes usually based on tickets raised by the organisations tagged to the page.
@@ -99,7 +103,9 @@ You will not be able to see which organisations are tagged to a mainstream page,
 
 If your organisation is not tagged, they can direct you to the tagged organisations' content teams. You can ask them to raise a ticket.
 
-[Ask GDS for if you want to change mainstream content](/accounts-support/make-content-requests/ask-updates-content/).
+[Ask GDS for help if you want to change mainstream content](/accounts-support/make-content-requests/ask-updates-content/).
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
 
 ### If your content is on any other type of page
 
@@ -109,6 +115,7 @@ You will not be able to update content if it's in 'history mode'. If it's in his
 
 If you want to update content in history mode, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new).
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
 
 
 *[GDS]: Government Digital Service

--- a/app/writing-to-gov-uk-standards/plan-manage-content/retire-content.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/retire-content.md
@@ -139,4 +139,7 @@ Before a general election, affected organisations will be asked by GDS to do a h
 
 If you think content should be removed from history mode after it’s been applied, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new).
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
+
 *[GDS]: Government Digital Service

--- a/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
+++ b/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
@@ -55,7 +55,9 @@ Consider whether there's a cross-government need for a consistent style. If the 
 
 ### How to suggest a change
 
-[Raise a support ticket](https://support.publishing.service.gov.uk/content_advice_request/new). You'll need a GOV.UK Signon account. If you do not have one, contact your organisation's GOV.UK content lead to send a ticket for you.
+[Raise a support ticket](https://support.publishing.service.gov.uk/content_advice_request/new). 
+
+You'll need a GOV.UK Signon account with ‘content requesters’ permissions to raise a support ticket. If you do not have one, speak to your GOV.UK lead or managing editor to send a ticket for you or arrange access to the support request form.
 
 In your ticket, include:
 


### PR DESCRIPTION
Added mention against the content advice form on various pages to make it clear that users need to have 'content requesters' permission to access the form. 