### PR TITLE
Add 'Record user needs' and fix typos and errors

### DIFF
--- a/app/publish-update-retire-content/organisations-people/groups.md
+++ b/app/publish-update-retire-content/organisations-people/groups.md
@@ -154,7 +154,7 @@ Do not attach more than the previous 6 months of minutes. Link to the [National 
 
 You can use either an inline link or a publication box.
 
-## No images available
+## Images
 
 {% include 'reusable-content/add-images-not-available.md' %}
 

--- a/app/publish-update-retire-content/standard-content-types/calls-for-evidence.md
+++ b/app/publish-update-retire-content/standard-content-types/calls-for-evidence.md
@@ -36,6 +36,9 @@ You can then add a final outcome to explain the government's response to the cal
 
 {% include 'reusable-content/signon-account-whitehall.md' %}
 
+
+{% include 'reusable-content/remove-history-mode.md' %}
+
 ### If you're creating a new call for evidence
 
 1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
@@ -82,8 +85,6 @@ If you're uploading a HTML attachment, read the [formatting guidance](/formattin
 9. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). If you do, select the relevant option under 'Do users have to know the content has changed?' and add your change notes (you can edit them again before you publish the draft).
 10. Select the 'Save' button at the bottom of the page.
 11. Go to the 'Attachments' tab if you want to edit any of the documents. You can quickly overwrite previous versions of attachments if you upload new files with the same file names as your old ones.
-
-{% include 'reusable-content/remove-history-mode.md' %}
 
 ### If you're adding a final outcome to a closed call for evidence
 

--- a/app/publish-update-retire-content/standard-content-types/consultations.md
+++ b/app/publish-update-retire-content/standard-content-types/consultations.md
@@ -43,6 +43,7 @@ Do not add any more information or attachments to the page after the government 
 
 {% include 'reusable-content/signon-account-whitehall.md' %}
 
+
 {% include 'reusable-content/remove-history-mode.md' %}
 
 ### If you're creating a new consultation

--- a/app/publish-update-retire-content/standard-content-types/news-articles.md
+++ b/app/publish-update-retire-content/standard-content-types/news-articles.md
@@ -15,6 +15,15 @@ lastUpdated:
 
 Use the news article content type to share news and updates about the government's work.
 
+You can also use this type to set out details about future events that your organisation is holding. Use a [document collection](/publish-update-retire-content/standard-content-types/document-collections/) to collect multiple news articles if you're holding a programme of events.
+
+Do not create a news article to:
+
+* collect together links to other content – use the [document collection type](/publish-update-retire-content/standard-content-types/document-collections/) or a [topical event page](/publish-update-retire-content/promotional-social/topical-events/) instead
+* promote the publication of other content, like statistics
+* provide guidance to users – use the [guidance publication type](/publish-update-retire-content/standard-content-types/publications/) or [detailed guide type](/publish-update-retire-content/standard-content-types/publications/) instead
+* duplicate another organisation's news article – consider publishing a news article jointly, or cover the same story from different angles or for different audiences
+
 ## Choose the right type of news article
 
 There are different types of news articles. Make sure you choose the right type.
@@ -30,17 +39,17 @@ There are different types of news articles. Make sure you choose the right type.
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Government response</th>
       <td class="govuk-table__cell"><p class="govuk-body">Government statements produced in response to media coverage by your organisation's press team. For example, rebuttals or 'myth busters'. These are usually short and to the point, consisting of a quotation with no headings.</p></td>
-      <td class="govuk-table__cell"><p class="govuk-body">Statements issued to Parliament.</p><p class="govuk-body">Speeches or press articles.</p><p class="govuk-body">Letters to newspapers written by ministers.</p><p class="govuk-body">Use the <a href="/publish-update-retire-content/standard-content-types/speeches/" class="govuk-link">speech type</a> for all of these instead.</p></td>
+      <td class="govuk-table__cell"><p class="govuk-body">Statements issued to Parliament, speeches, press articles and letters to newspapers written by ministers. Use the <a href="/publish-update-retire-content/standard-content-types/speeches/" class="govuk-link">speech type</a> for all of these instead.</p></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">News story</th>
-      <td class="govuk-table__cell"><p class="govuk-body">News content written only for GOV.UK which users need, can act on, would expect to get directly from the government and cannot get from other sources. For example, the opening of a government grant scheme or a change to public services that affects public sector employees.<p class="govuk-body">The content should be self-contained. It should be possible to delete it from the site without affecting anything else.</p><p class="govuk-body">You can also use this to set out details about future events that your organisation is holding. Use a <a href="/publish-update-retire-content/standard-content-types/document-collections/" class="govuk-link">document collection</a> to collect multiple news stories if you're holding a programme of events.</p></td>
-      <td class="govuk-table__cell"><p class="govuk-body">Information that puts your organisation's views on record. Use the government response type instead.</p><p class="govuk-body">Duplication of press releases or <a href="/publish-update-retire-content/standard-content-types/fatality-notices/" class="govuk-link">fatality notices</a>.</p><p class="govuk-body">Duplication of another organisation's news story. Consider publishing a news story jointly, or cover the same story from different angles or for different audiences.<br><br> Promotion of the publication of other content, like statistics.</p><p class="govuk-body">General purpose content pages or just to link through to other GOV.UK content. Guidance for users. Link to a <a href="/publish-update-retire-content/standard-content-types/publications/" class="govuk-link">guidance publication</a> or <a href="/publish-update-retire-content/standard-content-types/detailed-guides/" class="govuk-link">detailed guide</a> if there's something a user can act on.</p></td>
+      <td class="govuk-table__cell"><p class="govuk-body">News content written only for GOV.UK which users need, can act on, would expect to get directly from the government and cannot get from other sources. For example, the opening of a government grant scheme or a change to public services that affects public sector employees. The content should be self-contained so it can be deleted from the site without affecting anything else.</p></td>
+      <td class="govuk-table__cell"><p class="govuk-body">Duplication of press releases or <a href="/publish-update-retire-content/standard-content-types/fatality-notices/" class="govuk-link">fatality notices</a>.</p></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Press release</th>
-      <td class="govuk-table__cell"><p class="govuk-body">Unedited press releases as sent to the media. You can put additional notes at the end under a 'Background' heading.</p> <p class="govuk-body">Official statements by an organisation spokesperson.</p><p class="govuk-body">Official statements made by a minister, apart from parliamentary statements.</p></td>
-      <td class="govuk-table__cell"><p class="govuk-body">Ministerial statements issued to Parliament. Use the <a href="/publish-update-retire-content/standard-content-types/speeches/" class="govuk-link">speech type</a> instead.<p class="govuk-body"><p class="govuk-body">Promotion of the publication of other content, like statistics.</p><p class="govuk-body">Guidance for users. Link to a <a href="/publish-update-retire-content/standard-content-types/publications/" class="govuk-link">guidance publication</a> or <a href="/publish-update-retire-content/standard-content-types/detailed-guides/" class="govuk-link">detailed guide</a> if there's something a user can act on.</p></td>
+      <td class="govuk-table__cell"><p class="govuk-body">Unedited press releases as sent to the media (with additional notes at the end under a ‘Background’ heading). Also, official statements by an organisation spokesperson or by a minister (apart from parliamentary statements).</p></td>
+      <td class="govuk-table__cell"><p class="govuk-body">Ministerial statements issued to Parliament. Use the <a href="/publish-update-retire-content/standard-content-types/speeches/" class="govuk-link">speech type</a> instead.</p></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">World news story</th>

--- a/app/writing-to-gov-uk-standards/plan-manage-content/identify-user-needs.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/identify-user-needs.md
@@ -14,7 +14,7 @@ Every piece of published content should meet a valid user need.
 
 Writing good user needs means we can create content to help our users do the things they need to.
 
-## How to find out your user's needs
+## Find out your users' needs
 
 Content designers are not user researchers. As users and their needs become more complex, you will ideally work with user researchers to learn about your users and their needs. However, there are things you can do yourself to learn about your users' needs.
 
@@ -36,7 +36,7 @@ There are other [data and analytics tools you can use to support your content de
 
 If you feel like you cannot learn enough from your users this way, try to work with user researchers or performance analysts to go further.
 
-## How to write a user need
+## Write a user need
 
 All GOV.UK user needs follow the same template, with 3 parts.
 
@@ -114,7 +114,7 @@ This is not a valid user need because it creates a 'need' to justify existing co
 
 Assumptions we make when designing a piece of content or service can often be wrong. We need to find the best solution to meet each user need.
 
-## Consider using acceptance criteria
+## Write acceptance criteria
 
 Acceptance criteria can help define a user need by listing what must be done for the need to be met.
 
@@ -125,3 +125,17 @@ For example, from the 'good example' used above, the acceptance criteria could b
 * can apply for Carer's Allowance
 * understands how much they are entitled to
 
+## Record user needs
+
+You should record and store any user needs for content you create. You may find it helpful to keep information about:
+
+* when the user need is met (acceptance criteria)
+* any supporting evidence for the need
+* why the need is in [proposition for GOV.UK](https://www.gov.uk/government/publications/govuk-proposition/govuk-proposition)
+
+The primary publishing organisation (the organisation responsible for owning, publishing and maintaining the content) should maintain a record of user needs and content meeting that need.
+
+You can maintain a list of user needs by using:
+
+* a spreadsheet
+* an online database tool (following your organisation’s policy on online tools)

--- a/app/writing-to-gov-uk-standards/plan-manage-content/index.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/index.md
@@ -16,7 +16,8 @@ This guidance includes:
 * how to [identify user needs](/writing-to-gov-uk-standards/plan-manage-content/identify-user-needs/) and write a user need
 * how you should [plan new GOV.UK content](/writing-to-gov-uk-standards/plan-manage-content/plan-new-govuk-content/), including where it will go and how to help users find it
 * how to find and [manage your existing GOV.UK content](/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content/)
+* how to [approach accessibility](/writing-to-gov-uk-standards/plan-manage-content/understand-accessibility/)
 * the [standards for GOV.UK URLs](/writing-to-gov-uk-standards/plan-manage-content/follow-url-standards/)
 * when you should consider [adding translated versions of our content](/writing-to-gov-uk-standards/plan-manage-content/consider-translations/)
-* how [content can be grouped](/writing-to-gov-uk-standards/plan-manage-content/organise-group-govuk-content/) into topics, collections and step-by-step pages
+* how to [group content](/writing-to-gov-uk-standards/plan-manage-content/organise-group-govuk-content/) into topics, collections and step-by-step pages
 * when to [withdraw or unpublish content, and when content goes into 'history mode'](/writing-to-gov-uk-standards/plan-manage-content/retire-content)

--- a/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
+++ b/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
@@ -219,10 +219,6 @@ Title case.
 
 The abbreviation should come first as it's more widely known than the full name. Please note that the abbreviation has changed to Bacs.
 
-### backend
-
-Used in a technical context, not "back-end" or "back end".
-
 ### Bank details
 
 When adding bank details:
@@ -262,7 +258,7 @@ Always use billion in money (and million): £138 billion.
 
 Use billions in phrases: billions of people.
 
-Do not use £0.xx billion for amounts less than £1 billion, unless it's in a sequence where you're talking about amounts above £1 billion. For example: "There was £15.6 billion spent in August 2024, an increase of £0.2 billion". If you're using it outside of the sequence again, use £2 million. 
+Do not use £0.xx billion for amounts less than £1 billion, unless it's in a sequence where you're talking about amounts above £1 billion. For example: "There was £15.6 billion spent in August 2024, an increase of £0.2 billion". If you're using it outside of the sequence again, use £200 million. 
 
 Do not abbreviate billion to b.
 
@@ -592,15 +588,6 @@ Lower case.
 
 Lower case unless used in the full title, like the National Assembly for Wales (Legislative Competence) (Social Welfare) Order 2008.
 
-### Components that control other components
-
-In technical writing, use:
-
-- primary for a component that controls other components
-- secondary for a component that's controlled by the primary component
-
-Do not use master or slave.
-
 ### conduct of business rules
 
 Lower case.
@@ -755,7 +742,7 @@ When writing date ranges:
 * if the range is showing opening times on days, put different days on a new line - for example, 'Monday to Friday, 9am to 5pm', then 'Saturday, 10am to 1pm' on a new line
 * do not use quarter for dates, use the months - for example, 'department expenses, Jan to Mar 2013'
 * when referring to today (as in a news article) include the date - for example, 'The minister announced today (14 June 2012) that…'
-* when mentioning a deadline, use 'one or before' - for example, 'Submit the form on or before 6 September 2025'
+* when mentioning a deadline, use 'on or before' - for example, 'Submit the form on or before 6 September 2025'
 
 ### Daycare Trust
 
@@ -1254,10 +1241,6 @@ Hyphenated.
 
 Lower case.
 
-### HTTPS
-
-Upper case. No need to explain the abbreviation if it's used in content for a technical audience.
-
 ### human resources
 
 Lower case.
@@ -1359,10 +1342,6 @@ Lower case.
 ### Intrastat Supplementary Declaration
 
 Title case.
-
-### IP
-
-When used in the technical context (for example 'internet protocol'), there's no need to explain the abbreviation.
 
 ### Italics
 
@@ -1540,10 +1519,6 @@ Use the minus sign for subtraction. Use the correct symbol for the multiplicatio
 Write out and hyphenate fractions: two-thirds, three-quarters.
 
 Write out decimal fractions as numerals. Use the same number format for a sequence: 0.75 and 0.45.
-
-### MD5
-
-Used in a technical context there's no need to explain the abbreviation.
 
 ### Measurements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,7 +1436,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -1453,7 +1454,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -2162,7 +2164,6 @@
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
       "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -2520,7 +2521,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -2892,7 +2892,6 @@
       "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.7.tgz",
       "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -3010,7 +3009,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },


### PR DESCRIPTION
Adding a new section to 'Identify user needs' about recording user needs. This was in the old guidance but had not been copied over. Also updating the headings on the page for readability.

Also, making a variety of small changes to fix typos and errors. This includes:

- Style guide A to Z: removing duplication with the technical content style guide, updating the 'billions' and 'Dates' entries to fix typos
- Calls for evidence: moving the content about history mode further up the page, as it applies to all stages
- Consultations: fixing a paragraph spacing issue
- News article: removing line breaks and duplication from the table, which involved taking some content out of the table and putting it further up the page as it applies to all subtypes
- Group pages: updating the images heading to standardise it with other pages
- Plan and manage content: adding link to new accessibility content