### PR TITLE
Update snippets and add information about corporate information tagging

### DIFF
--- a/app/publish-update-retire-content/corporate-information/index.md
+++ b/app/publish-update-retire-content/corporate-information/index.md
@@ -23,21 +23,25 @@ When you publish a corporate information page, a link to it will appear automati
 
 To add a page:
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'Organisations'.
 4. Search for the organisation and select 'View' next to its name. 
 5. Select the 'Pages' tab.
 6. Select 'Create a new corporate information page' to add a new page.
 7. Select the type of page and fill in the summary and body.
-8. When you're happy with the content, select 'Submit for 2nd eyes' so another editor can review the page and publish.
+8. Select 'Save and go to document summary’. 
+9. Under the ‘Topic taxonomy tags’ heading, select ‘Add tags’. Tick the boxes next to each topic that applies and select 'Save'.
+10. When you're happy with the content, select 'Submit for 2nd eyes' so another editor can review the page and publish.
 
 To edit a page:
 
 1. On your organisation page, select the 'Pages' tab.
-2. Select 'view' on the page you want to edit.
+2. Select 'View' on the page you want to edit.
 3. Edit the summary or body text as required.
-4. When you're happy with the content, select 'Submit for 2nd eyes' so another editor can review the page and publish.
+4. When you're happy with the content, select 'Save and go to document summary'.
+5. Select 'Submit for 2nd eyes' so another editor can review the page and publish.
 
 ## Add or edit attachments to a corporate information page
 

--- a/app/publish-update-retire-content/organisations-people/groups.md
+++ b/app/publish-update-retire-content/organisations-people/groups.md
@@ -57,7 +57,8 @@ Once you have permission, you can add the page.
 
 You need to:
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'Groups'.
 

--- a/app/publish-update-retire-content/organisations-people/organisations.md
+++ b/app/publish-update-retire-content/organisations-people/organisations.md
@@ -25,7 +25,8 @@ Your GOV.UK lead or a managing editor needs to [ask the Government Digital Servi
 
 To find an organisation page:
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'Organisations'.
 4. Search for the organisation and select 'View' next to its name. 

--- a/app/publish-update-retire-content/organisations-people/people-roles.md
+++ b/app/publish-update-retire-content/organisations-people/people-roles.md
@@ -68,7 +68,8 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
 >[!NOTE]
 >When adding or editing a people page, be aware that it will publish or update as soon as you select ‘Save’ – there’s no draft state or peer review.
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'People'.
 4. Check that there's not already a page for the person using the search bar.
@@ -107,7 +108,8 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
 
 To add a new role page:
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'Roles'.
 4. Select 'Create new role'.
@@ -160,7 +162,8 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
 >[!NOTE]
 >When assigning a role to a person, be aware that it will update as soon as you select ‘Save’ – there’s no draft state or peer review.
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'Roles'.
 4. Search for the role title and select 'Edit'. 

--- a/app/publish-update-retire-content/organisations-people/worldwide.md
+++ b/app/publish-update-retire-content/organisations-people/worldwide.md
@@ -33,7 +33,8 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
 
 ### Edit a world locations news page
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'World location news'.
 4. Select 'View' next to the relevant location.
@@ -44,7 +45,8 @@ Any changes you make to the page will appear instantly on the live site.
 
 1. Select the 'Details' tab.
 2. Select 'Edit'.
-3. Edit the text in the 'Mission statement' field. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
+3. Edit the text in the 'Mission statement' field. {% include 'reusable-content/style-formatting.md' %}
+
 4. Select 'Preview' at the top of the 'Mission statement' field to check the text is correctly formatted.
 5. When you've finished, select 'Save'.
 
@@ -119,7 +121,8 @@ If you want to add a new translation:
 
 If you want to update an existing translation:
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'World location news'.
 4. Select the relevant translation next to the location.
@@ -134,7 +137,8 @@ You usually only need to make changes to existing worldwide organisations. Do no
 
 Only create a new worldwide organisation page if you have permission from a managing editor or your GOV.UK lead.
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select 'New document'.
 3. Select 'Worldwide organisation' and then select 'Next'.
 4. Complete the title, summary and body text.
@@ -151,13 +155,14 @@ If you need to publish it urgently without a review, find out when you can [publ
 
 ### Edit an existing world organisation page
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'Worldwide organisations'.
 4. Select 'View' next to the relevant location.
 5. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link instead. You can then select 'Edit draft', or select 'Delete draft' if you want to start a fresh draft.
 6. Make any changes to the title, summary or body as needed.
-7. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again later).
+7. {% include 'reusable-content/change-notes.md' %}
 8. Select the 'Save' button at the bottom of the page.
 
 You can now add or edit translations, attachments, offices, information pages and social media accounts.
@@ -332,7 +337,8 @@ You can tag this content yourself if it's been published by the Foreign, Commonw
 To tag the content:
 
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Find the document you want to tag and select 'View'.
 4. Under 'Worldwide', select 'Add tags'.

--- a/app/publish-update-retire-content/promotional-social/topical-events.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events.md
@@ -40,7 +40,8 @@ Once you have that approval, then you can add a new page.
 
 ## Add or edit a topical event page
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'More' tab.
 3. Select 'Topical events'.
 

--- a/app/publish-update-retire-content/standard-content-types/calls-for-evidence.md
+++ b/app/publish-update-retire-content/standard-content-types/calls-for-evidence.md
@@ -41,7 +41,8 @@ You can then add a final outcome to explain the government's response to the cal
 
 ### If you're creating a new call for evidence
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'Call for evidence' and then select the 'Next' button.
 4. If the call for evidence is not in English, tick 'Create a foreign language only call for evidence' and select the language.
@@ -73,16 +74,19 @@ If you're uploading a HTML attachment, read the [formatting guidance](/formattin
 
 ### If you're updating a call for evidence
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the call for evidence you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link instead. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Make any changes to the title, summary and body as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
-6. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only need to be changed if your organisation is asked to take part in an audit of content before a general election.
+5. Make any changes to the title, summary and body as needed. {% include 'reusable-content/style-formatting.md' %}
+
+6. {% include 'reusable-content/political-heading.md' %}
+
 7. Change the options under 'Excluded nations (required)' if needed.
 8. {% include 'reusable-content/limit-access.md' %}
 
-9. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). If you do, select the relevant option under 'Do users have to know the content has changed?' and add your change notes (you can edit them again before you publish the draft).
+9. {% include 'reusable-content/change-notes.md' %}
 10. Select the 'Save' button at the bottom of the page.
 11. Go to the 'Attachments' tab if you want to edit any of the documents. You can quickly overwrite previous versions of attachments if you upload new files with the same file names as your old ones.
 
@@ -90,13 +94,13 @@ If you're uploading a HTML attachment, read the [formatting guidance](/formattin
 
 Do not change the original content or documents. They will move to the bottom of the page under the heading 'Original call for evidence'.
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the call for evidence you want to edit, and select the 'View' link next to it. This will take you to the edition summary page.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish anything).
+5. {% include 'reusable-content/change-notes.md' %}
 6. {% include 'reusable-content/limit-access.md' %}
-
 7. Select the 'Save' button at the bottom of the page.
 8. Select the 'Final outcome' tab at the top of the page. Add a publication date and content to describe the outcome.
 9. Select 'Save'.

--- a/app/publish-update-retire-content/standard-content-types/case-studies.md
+++ b/app/publish-update-retire-content/standard-content-types/case-studies.md
@@ -38,7 +38,8 @@ Remember, most users just want practical guidance. Case studies can make it hard
 
 ### If you're creating a new case study
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'Case study' and then select the 'Next' button.
 4. Add the title. It should summarise the point of the case study, like 'UK money helps to build homes in Darfur'.
@@ -55,15 +56,18 @@ After saving the page, you can add images and attachments.
 
 ### If you're updating an existing case study
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the case study you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Make any changes to the title, summary or body as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
-6. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only need to be changed if your organisation is asked to take part in an audit of content before a general election.
+5. Make any changes to the title, summary or body as needed. {% include 'reusable-content/style-formatting.md' %}
+
+6. {% include 'reusable-content/political-heading.md' %}
+
 7. {% include 'reusable-content/limit-access.md' %}
 
-8. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish the draft).
+8. {% include 'reusable-content/change-notes.md' %}
 9. Select the 'Save' button at the bottom of the page.
 
 {% include 'reusable-content/remove-history-mode.md' %}

--- a/app/publish-update-retire-content/standard-content-types/consultations.md
+++ b/app/publish-update-retire-content/standard-content-types/consultations.md
@@ -48,7 +48,8 @@ Do not add any more information or attachments to the page after the government 
 
 ### If you're creating a new consultation
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'Consultation' and then select the 'Next' button.
 4. If the consultation is not in English, tick 'Create a foreign language only consultation' and select the language.
@@ -81,16 +82,19 @@ If you're uploading a HTML attachment, read the [formatting guidance](/formattin
 
 ### If you're updating an open consultation
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the consultation you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Make any changes to the title, summary and body as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
-6. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only need to be changed if your organisation is asked to take part in an audit of content before a general election.
+5. Make any changes to the title, summary and body as needed. {% include 'reusable-content/style-formatting.md' %}
+
+6. {% include 'reusable-content/political-heading.md' %}
+
 7. Change the options under 'Excluded nations (required)' if needed.
 8. {% include 'reusable-content/limit-access.md' %}
 
-9. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). If you do, select the relevant option under 'Do users have to know the content has changed?' and add your change notes (you can edit them again before you publish the draft).
+9. {% include 'reusable-content/change-notes.md' %}
 10. Select the 'Save' button at the bottom of the page.
 11. Go to the 'Attachments' tab if you want to edit any of the consultation documents. You can quickly overwrite previous versions of attachments if you upload new files with the same file names as your old ones.
 
@@ -103,13 +107,14 @@ You can update the consultation to:
 
 Do not change the original content or consultation documents. They will move to the bottom of the page under the heading 'Original consultation'.
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the consultation you want to edit, and select the 'View' link next to it. This will take you to the edition summary page.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link instead. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
 5. {% include 'reusable-content/limit-access.md' %}
 
-6. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). If you do, go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?' and add your change notes (you can edit them again later).
+6. {% include 'reusable-content/change-notes.md' %}
 7. Select the 'Save' button at the bottom of the page.
 8. Select the 'Public feedback' tab at the top of the page.
 
@@ -132,13 +137,14 @@ If you're uploading a HTML attachment, read the [formatting guidance](/formattin
 
 Do not change the original content or consultation documents. They will move to the bottom of the page under the heading 'Original consultation'.
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the consultation you want to edit, and select the 'View' link next to it. This will take you to the edition summary page.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link instead. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
 5. {% include 'reusable-content/limit-access.md' %}
 
-6. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again later).
+6. {% include 'reusable-content/change-notes.md' %}
 7. Select the 'Save' button at the bottom of the page.
 8. Select the 'Final outcome' tab at the top of the page. Add a publication date and use the 'Summary' to describe briefly what form the response takes, but do not describe what the response says.
 9. Select 'Save'.

--- a/app/publish-update-retire-content/standard-content-types/detailed-guides.md
+++ b/app/publish-update-retire-content/standard-content-types/detailed-guides.md
@@ -25,10 +25,12 @@ Content containing background information about why a user needs to complete a t
 
 ### If you're creating a new detailed guide
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'Detailed guide' and then select the 'Next' button.
-4. Add the title, summary and body. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
+4. Add the title, summary and body. {% include 'reusable-content/style-formatting.md' %}
+
 5. Tick the UK nations where the content applies under 'Excluded nations (required)'. If your content does not apply to a nation, you can optionally provide a link to alternative content for users in that nation.
 6. {% include 'reusable-content/limit-access.md' %}
 
@@ -38,16 +40,19 @@ After saving the page, you can add attachments and images.
 
 ### If you're updating an existing detailed guide
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the detailed guide you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Make any changes to the title, summary or body as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
-6. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only need to be changed if your organisation is asked to take part in an audit of content before a general election.
+5. Make any changes to the title, summary or body as needed. {% include 'reusable-content/style-formatting.md' %}
+
+6. {% include 'reusable-content/political-heading.md' %}
+
 7. Change the options under 'Excluded nations (required)' if needed.
 8. {% include 'reusable-content/limit-access.md' %}
 
-9. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish the draft).
+9. {% include 'reusable-content/change-notes.md' %}
 10. Select the 'Save' button at the bottom of the page.
 
 You can now edit the attachments and images.

--- a/app/publish-update-retire-content/standard-content-types/document-collections.md
+++ b/app/publish-update-retire-content/standard-content-types/document-collections.md
@@ -39,11 +39,13 @@ Do not create a collection:
 
 ### If you're creating a new document collection
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'Document collection' and then select the 'Next' button.
 4. If the document collection is not in English, tick 'Create a foreign language only document collection' and select the language.
-5. Add the title and summary. You can add a further description of the collection to the body. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
+5. Add the title and summary. You can add a further description of the collection to the body. {% include 'reusable-content/style-formatting.md' %}
+
 6. {% include 'reusable-content/limit-access.md' %}
 
 7. Select the 'Save' button at the bottom of the page.
@@ -52,15 +54,18 @@ After saving the page, you can start adding the collection itself.
 
 ### If you're updating an existing document collection
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the document collection you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Make any changes to the title, summary and body as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
-6. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only need to be changed if your organisation is asked to take part in an audit of content before a general election.
+5. Make any changes to the title, summary and body as needed. {% include 'reusable-content/style-formatting.md' %}
+
+6. {% include 'reusable-content/political-heading.md' %}
+
 7. {% include 'reusable-content/limit-access.md' %}
 
-8. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish the draft).
+8. {% include 'reusable-content/change-notes.md' %}
 9. Select the 'Save' button at the bottom of the page.
 
 After saving the page, you can start editing the collection itself.
@@ -147,7 +152,7 @@ To reorder content in the group:
 
 ## Update settings of the draft
 
-{% include 'reusable-content/update-settings-attachments.md' %}
+{% include 'reusable-content/update-settings-no-attachments.md' %}
 
 ## Add or remove topic tags
 

--- a/app/publish-update-retire-content/standard-content-types/fatality-notices.md
+++ b/app/publish-update-retire-content/standard-content-types/fatality-notices.md
@@ -30,7 +30,8 @@ If there were multiple deaths in one incident, create a fatality notice for the 
 
 ### If you're creating a new fatality notice
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'Fatality notice' and then select the 'Next' button.
 4. In the 'Title', add the names and titles of the people who died.
@@ -48,14 +49,15 @@ After saving the page, you can now add images of the people if you have them. Yo
 
 ### If you're updating an existing fatality notice
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the fatality notice you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
 5. Make any changes to the title, summary, body and fatality notice details as needed.
 6. {% include 'reusable-content/limit-access.md' %}
 
-7. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish the draft).
+7. {% include 'reusable-content/change-notes.md' %}
 8. Select the 'Save' button at the bottom of the page.
 
 You can now edit the images.
@@ -88,7 +90,7 @@ There's a default image that appears on every fatality notice before the body co
 
 ## Update settings of the draft
 
-{% include 'reusable-content/update-settings-attachments.md' %}
+{% include 'reusable-content/update-settings-no-attachments.md' %}
 
 ## Add or remove topic tags
 

--- a/app/publish-update-retire-content/standard-content-types/news-articles.md
+++ b/app/publish-update-retire-content/standard-content-types/news-articles.md
@@ -65,11 +65,13 @@ There are different types of news articles. Make sure you choose the right type.
 
 ### If you're creating a new article
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'News article' and then select the 'Next' button.
 4. Choose the type of news article from the following page and select ‘Next’.
-5. Add the title, summary and body. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
+5. Add the title, summary and body. {% include 'reusable-content/style-formatting.md' %}
+
 6. {% include 'reusable-content/limit-access.md' %}
 
 7. If you're creating a world news story, tag the story to a world location and worldwide organisation under the 'Associations' heading.
@@ -85,15 +87,18 @@ If a news article is outdated, consider [withdrawing or unpublishing the existin
 
 If you're correcting an error:
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the news article you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Make any changes to the title, summary or body as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
-6. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only need to be changed if your organisation is asked to take part in an audit of content before a general election.
+5. Make any changes to the title, summary or body as needed. {% include 'reusable-content/style-formatting.md' %}
+
+6. {% include 'reusable-content/political-heading.md' %}
+
 7. {% include 'reusable-content/limit-access.md' %}
 
-8. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish the draft).
+8. {% include 'reusable-content/change-notes.md' %}
 9. Select the 'Save' button at the bottom of the page.
 
 You can now edit the images and attachments.

--- a/app/publish-update-retire-content/standard-content-types/publications.md
+++ b/app/publish-update-retire-content/standard-content-types/publications.md
@@ -150,7 +150,8 @@ There are different types of publications. Make sure you choose the right type, 
 
 ### If you're creating a new publication
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'Publication' and then select the 'Next' button.
 4. Select the content type from the dropdown under 'Publication type (required)'.
@@ -170,16 +171,18 @@ After saving the page, you can add attachments and images.
 
 ### If you're updating an existing publication
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the publication you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only need to be changed if your organisation is asked to take part in an audit of content before a general election.
+5. {% include 'reusable-content/political-heading.md' %}
+
 6. Make any changes to the title, summary or body as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
 7. Change the options under 'Excluded nations (required)' if needed.
 8. {% include 'reusable-content/limit-access.md' %}
 
-9. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish the draft).
+9. {% include 'reusable-content/change-notes.md' %}
 10. Select the 'Save' button at the bottom of the page.
 
 You can now edit the attachments and images.

--- a/app/publish-update-retire-content/standard-content-types/speeches.md
+++ b/app/publish-update-retire-content/standard-content-types/speeches.md
@@ -46,7 +46,8 @@ Before you start, decide whether the speech should be marked as:
 
 ### If you're creating a new speech
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'Speech' and then select the 'Next' button.
 4. Select the content type from the dropdown under 'Speech type'.
@@ -73,15 +74,18 @@ If a speech is outdated, consider [withdrawing it](/publish-update-retire-conten
 
 If you're correcting an error:
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the speech you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Make any changes to the title, summary, body and speech details as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
-6. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only need to be changed if your organisation is asked to take part in an audit of content before a general election.
+5. Make any changes to the title, summary, body and speech details as needed. {% include 'reusable-content/style-formatting.md' %}
+
+6. {% include 'reusable-content/political-heading.md' %}
+
 7. {% include 'reusable-content/limit-access.md' %}
 
-8. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish the draft).
+8. {% include 'reusable-content/change-notes.md' %}
 9. Select the 'Save' button at the bottom of the page.
 
 You can now edit the images.
@@ -118,7 +122,7 @@ Update their photo on their people page if it needs changing.
 
 ## Update settings of the draft
 
-{% include 'reusable-content/update-settings-attachments.md' %}
+{% include 'reusable-content/update-settings-no-attachments.md' %}
 
 ## Add or remove topic tags
 

--- a/app/publish-update-retire-content/standard-content-types/statistical-data-sets.md
+++ b/app/publish-update-retire-content/standard-content-types/statistical-data-sets.md
@@ -26,10 +26,12 @@ For data sets you publish less frequently or with analysis, use [statistics cont
 
 ### If you're creating a new statistical data set
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'New document' tab.
 3. Select 'Statistical data set' and then select the 'Next' button.
-4. Add the title, summary and body. Read the [tone of voice guidance](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
+4. Add the title, summary and body. {% include 'reusable-content/style-formatting.md' %}
+
 5. {% include 'reusable-content/limit-access.md' %}
 
 6. Select the 'Save' button at the bottom of the page.
@@ -38,15 +40,18 @@ After saving the page, you can add the data set as an attachment.
 
 ### If you're updating an existing statistical data set
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Documents' tab.
 3. Search for the statistical data set you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
-5. Make any changes to the title, summary or body as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
-6. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only need to be changed if your organisation is asked to take part in an audit of content before a general election.
+5. Make any changes to the title, summary or body as needed. {% include 'reusable-content/style-formatting.md' %}
+
+6. {% include 'reusable-content/political-heading.md' %}
+
 7. {% include 'reusable-content/limit-access.md' %}
 
-8. Decide whether you need to [write public change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish the draft).
+8. {% include 'reusable-content/change-notes.md' %}
 9. Select the 'Save' button at the bottom of the page.
 
 You can now edit the attachments.

--- a/app/publish-update-retire-content/standard-content-types/statistics.md
+++ b/app/publish-update-retire-content/standard-content-types/statistics.md
@@ -48,7 +48,8 @@ The title and summary are displayed in the release calendar and search engine re
 
 To create a statistics announcement: 
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin/).
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
 2. Select the 'Statistics announcements' tab.
 3. Select the 'Create announcement' link.
 4. Choose a statistics type. Only select the 'Accredited Official Statistics' option if your statistics have been awarded the [accredited official statistics badge](https://osr.statisticsauthority.gov.uk/accredited-official-statistics/) by the Office for Statistics Regulation (OSR).
@@ -113,8 +114,9 @@ When the statistics publication is published, the announcement will disappear fr
 2. Select 'View' next to the publication.
 3. Select the 'Edit' button.
 4. Make your changes.
-5. Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only be important if your organisation is asked to take part in a history mode audit.
-6. Decide whether you need to [write change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). Go to the bottom of the page and select the relevant option under 'Do users have to know the content has changed?', and add your change notes if needed (you can edit them again before you publish the draft).
+5. {% include 'reusable-content/political-heading.md' %}
+
+6. {% include 'reusable-content/change-notes.md' %}
 7. Select the 'Save' button at the bottom of the page.
 8. Select 'Submit for 2nd eyes'. This will allow another editor to [review your document](/publish-update-retire-content/standard-content-types/review-standard/) and then they can publish or schedule it.
 


### PR DESCRIPTION
Used a few snippets that we created but never actually added to the relevant pages:

- change-notes.md
- political-heading.md
- style-formatting.md
- whitehall-publisher.md

Also, corrected a few instances where 'update-settings-attachments.md' was used instead of 'update-settings-no-attachments.md' (for content types where you cannot add attachments).

Also, added steps to the corporate information guidance about adding tags to new corporate information pages. This was missing information.