### PR TITLE
Update topical events guidance

### DIFF
--- a/_includes/reusable-content/update-settings-no-attachments.md
+++ b/_includes/reusable-content/update-settings-no-attachments.md
@@ -1,4 +1,4 @@
-Under the 'Settings' heading, you can::
+Under the 'Settings' heading, you can:
 
 - select 'Schedule publication', if you want the draft published at a certain time and date
 - select 'Review date', if you want to get an email asking you to check the content at a later date after you've published it

--- a/app/publish-update-retire-content/promotional-social/topical-events-old.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events-old.md
@@ -1,0 +1,154 @@
+---
+layout: landing-page
+sectionKey: Publish update or retire content
+eleventyNavigation:
+  parent: Promotional or social content types
+title: Topical event pages published before 24 April 2026
+description: How to edit old topical event pages, including 'About' pages.
+lastUpdated:
+---
+
+[[toc]]
+
+Topical event pages are used to communicate government activity about high-profile events or in response to a major crisis.
+
+If you want to request a new topical event page, [see our guidance for new topical event pages](/publish-update-retire-content/promotional-social/topical-events/). This page only covers topical event pages created before 24 April 2026 that you need to update.
+
+This guidance is temporary. In the coming months, all topical event pages will follow the newer guidance. 
+
+{% include 'reusable-content/signon-account-whitehall.md' %}
+
+
+## Edit a topical event page
+
+1. {% include 'reusable-content/whitehall-publisher.md' %}
+
+2. Select the 'More' tab.
+3. Select 'Topical events'.
+
+Search for the name of the group and select 'Edit' next to it.
+
+Once you've done this, you can edit the details of the page.
+
+>[!NOTE]
+>When editing an older topical event page, be aware that it will publish or update as soon as you select ‘Save’ – there’s no draft state or peer review.
+
+## Add or edit details
+
+Each topical page has a number of fields to fill in.
+
+### Name
+
+Use the name of the event and the year (for example 'D5 London 2014') and state if it's a government response to a crisis or event (for example 'Ebola virus: UK government response').
+
+Names must be unique and cannot be changed once published. They do not need a full stop. When you save your page this will become its 'slug', which users will see as the last section of the page URL.
+
+### Summary
+
+Give a summary of the topical event. Write it as a complete sentence with a full stop.
+
+### Description
+
+Keep the description short and use it to briefly explain:
+
+* what the event is 
+* how the government is involved
+* what users will find on the page
+
+You can also use it to link to related policies, statements of action or presentations.
+Do not repeat the title or summary.
+
+### Logo
+
+Add a logo if you have one. You do not need to provide alt text. If you add a logo it will show at the top of the page, next to the title and summary text. 
+
+### Duration
+
+Topical event pages are only relevant for a specific period of time, so you can set a start date and an end date.
+
+### Social media accounts
+
+Select any services being used for the event and add the URL. You can add a maximum of 7.
+
+### Publish the draft
+
+Select 'Save' to publish the topical event. The draft will go live immediately.
+
+If you're creating a new topical event, you can now tag organisations, add an 'About' page and feature content.
+
+## Tag an organisation
+
+1. Select the 'More' tab.
+2. Select 'Organisations'.
+3. Find the organisation you want to tag and select 'View' next to it.
+4. Select the 'Edit' link next to the 'Details' heading.
+5. Go to 'Topical events' and select the topical event from the drop down menu.
+6. Select 'Save'.
+
+You can make some of the tagged organisations 'leads'. This means their name and logo will show up on the topical event page under a 'Who's involved' heading.
+
+1. Go back to the topical event page.
+2. Select the 'Organisations' tab.
+3. Select 'Make lead' next to the relevant organisations.
+
+## Add or edit an 'About' page
+
+Use this page to give more detailed information on what the government is doing about the event.
+
+1. Select the 'About page' tab.
+2. Select 'Create new about page'.
+3. Add a name for the 'About' page. The name of the topical event page will automatically appear as the 'About' page title, so do not repeat this. 
+4. Add some 'Read more link text', following the guidance for [writing link text](/writing-to-gov-uk-standards/tone-of-voice/add-links/). The link text will appear below the summary on the main topical event page and direct users to the 'About' page.
+5. Complete the 'Summary' field using a maximum of 140 characters. Write it as a complete sentence with a full stop.
+6. Complete the 'Body' section.
+7. Select 'Save'. The draft will be published immediately.
+
+## Tag a piece of content to the topical event page
+
+You can tag content by adding an association to the topical event. You can do it for these content types:
+
+- [call for evidence](/publish-update-retire-content/standard-content-types/calls-for-evidence/)
+- [consultation](/publish-update-retire-content/standard-content-types/consultations/)
+- [detailed guide](/publish-update-retire-content/standard-content-types/detailed-guides/)
+- [document collection](/publish-update-retire-content/standard-content-types/document-collections/)
+- [news article](/publish-update-retire-content/standard-content-types/news-articles)
+- [publication](/publish-update-retire-content/standard-content-types/publications/)
+- [speech](/publish-update-retire-content/standard-content-types/speeches/)
+
+Content tagged to the topical event will automatically appear in the 'Latest' feed.
+
+## Feature tagged content
+
+You can feature up to 6 pieces of content. Any items you feature must include an image. Read the guidance on [formatting images](/formatting-content/images/) for help with picking an image.
+
+If the content is published through Whitehall Publisher:
+
+1. Select the 'Featured' tab.
+2. Select the 'GOV.UK content' tab.
+3. Search for the document you want to feature using the filters on the left hand side. Only content tagged to the topical event will show in the list.
+4. Select the 'Feature' link next to the document you would like to feature.
+5. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text.
+
+If the content is not published through Whitehall Publisher:
+
+1. Select the 'Featured' tab.
+2. Select the 'External websites' tab.
+3. Select 'Add an external link'.
+4. Complete the title, summary, type and URL fields and select 'Save'.
+5. Select the 'Feature' link next to the external page you would like to feature.
+6. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text.
+
+### Change the order of featured content
+
+You can change the order of featured content.
+
+1. Select the 'Featured' tab.
+2. Select 'Reorder pages' and then drag items up or down in the list.
+3. When you're done setting the order, select 'Update order'.
+
+### Unfeature content
+
+1. Select the 'Featured' tab.
+2. Select 'Unfeature' to remove featured content from your topical events page.
+
+*[GDS]: Government Digital Service

--- a/app/publish-update-retire-content/promotional-social/topical-events-old.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events-old.md
@@ -56,6 +56,7 @@ Keep the description short and use it to briefly explain:
 * what users will find on the page
 
 You can also use it to link to related policies, statements of action or presentations.
+
 Do not repeat the title or summary.
 
 ### Logo

--- a/app/publish-update-retire-content/promotional-social/topical-events.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events.md
@@ -171,6 +171,10 @@ You can change the order of featured content.
 1. Select the 'Featured' tab.
 2. Select 'Unfeature' to remove featured content from your topical events page.
 
+## Add or remove topic tags
+
+{% include 'reusable-content/add-remove-topic-tags.md' %}
+
 ## Publish the draft
 
 {% include 'reusable-content/publish-draft.md' %}

--- a/app/publish-update-retire-content/promotional-social/topical-events.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events.md
@@ -43,6 +43,7 @@ Once you have that approval, then you can add a new page.
 
 {% include 'reusable-content/signon-account-whitehall.md' %}
 
+
 Once you’ve created a draft, you need to add the title, summary and description fields before you can save it.  
 
 ### If you’re creating a new topical event page

--- a/app/publish-update-retire-content/promotional-social/topical-events.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events.md
@@ -10,6 +10,9 @@ lastUpdated:
 
 [[toc]]
 
+>[!NOTE]
+>If you need to edit a topical event page published before 24 April 2026, see our separate [guidance on older topical event pages](/publish-update-retire-content/promotional-social/topical-events-old/). This page is only for topical event pages added on or after 24 April 2026. 
+
 Topical event pages are used to communicate government activity about high-profile events or in response to a major crisis.
 
 Use for an event or crisis that is all of the following:
@@ -28,8 +31,6 @@ Do not use for:
 * events which can be reasonably covered by a lead news story on a departmental homepage (although news stories may develop into topical event pages following additional content generation or increased public interest)
 * influencing behaviour change – this is the role of [campaign sites](/publish-update-retire-content/promotional-social/campaigns/)
 
-{% include 'reusable-content/signon-account-whitehall.md' %}
-
 ## Get approval to create a new topical event page
 
 Your GOV.UK lead or a managing editor needs to [ask the Government Digital Service (GDS) for approval](https://support.publishing.service.gov.uk/content_advice_request/new) before creating the page.
@@ -38,88 +39,89 @@ The request will need to show that your event meets all of the above criteria.
 
 Once you have that approval, then you can add a new page.
 
-## Add or edit a topical event page
+## Create a draft
 
-1. Go to [Whitehall Publisher](https://whitehall-admin.publishing.service.gov.uk/government/admin).
-2. Select the 'More' tab.
-3. Select 'Topical events'.
+{% include 'reusable-content/signon-account-whitehall.md' %}
 
-If you're adding a new page, select 'Create topical event'. Otherwise, search for the name of the group and select 'Edit' next to it.
 
-Once you've done this, you can add or edit the details of the page.
+Once you’ve created a draft, you need to add the title, summary and description fields before you can save it.  
 
->[!NOTE]
->When adding or editing a topical event page, be aware that it will publish or update as soon as you select ‘Save’ – there’s no draft state or peer review.
+### If you’re creating a new topical event page
 
-## Add or edit details
+1. {% include 'reusable-content/whitehall-publisher.md' %}
 
-Each topical page has a number of fields to fill in.
+2. Select the 'New document' tab.
+3. Select ‘Topical event’ and then select the ‘Next’ button.
 
-### Name
+### If you’re updating an existing topical event page
 
-Use the name of the event and the year (for example 'D5 London 2014') and state if it's a government response to a crisis or event (for example 'Ebola virus: UK government response').
+1. {% include 'reusable-content/whitehall-publisher.md' %}
 
-Names must be unique and cannot be changed once published. They do not need a full stop. When you save your page this will become its 'slug', which users will see as the last section of the page URL.
+2. Select the ‘Documents’ tab.
+3. Search for the topical event you want to edit, and select the ‘View’ link next to it. This will take you to the edition summary page.
+4. Select the ‘Create new edition’ button. If a new edition has already been created, select the ‘Go to draft’ link. You can then select ‘Edit draft’ or, if you do not want to use this draft, select ‘Delete draft’ and then select ‘Create new edition’.
+
+## Add or edit the title, summary and body
+
+### Title
+
+Use the name of the event and the year (for example ‘D5 London 2014’) and state if it’s a government response to a crisis or event (for example ‘Ebola virus: UK government response’).
+
+Names must be unique and cannot be changed once published. They do not need a full stop. When you save your page this will become its ‘slug’, which users will see as the last section of the page URL.
 
 ### Summary
 
 Give a summary of the topical event. Write it as a complete sentence with a full stop.
 
-### Description
+### Body
 
 Keep the description short and use it to briefly explain:
 
-* what the event is 
+* what the event is
 * how the government is involved
 * what users will find on the page
 
-You can also use it to link to related policies, statements of action or presentations.
+You can also use it to link to related policies, statements of action or presentations. 
+
 Do not repeat the title or summary.
 
-### Logo
+## Tag organisations
 
-Add a logo if you have one. You do not need to provide alt text. If you add a logo it will show at the top of the page, next to the title and summary text. 
+Your own organisation will be set as a lead organisation as default, but you can change that or add any other organisations if they’re responsible for the content.
 
-### Duration
+Lead organisations will be listed on the topical event page in the order you add them in the draft. Supporting organisations will be shown in alphabetical order.
 
-Topical event pages are only relevant for a specific period of time, so you can set a start date and an end date.
+## Update settings of the draft
 
-### Social media accounts
+{% include 'reusable-content/update-settings-no-attachments.md' %}
 
-Select any services being used for the event and add the URL. You can add a maximum of 7.
+{% include 'reusable-content/limit-access.md' %}
 
-### Publish the draft
+## Add or edit social media accounts
 
-Select 'Save' to publish the topical event. The draft will go live immediately.
+You can add and remove social media accounts in the ‘Social media accounts’ tab. 
 
-If you're creating a new topical event, you can now tag organisations, add an 'About' page and feature content.
+To add an account, select the ‘Add a social media account’ button and then choose the channel type and add the URL.
 
-## Tag an organisation
+## Add or edit images
 
-1. Select the 'More' tab.
-2. Select 'Organisations'.
-3. Find the organisation you want to tag and select 'View' next to it.
-4. Select the 'Edit' link next to the 'Details' heading.
-5. Go to 'Topical events' and select the topical event from the drop down menu.
-6. Select 'Save'.
+You can add:
 
-You can make some of the tagged organisations 'leads'. This means their name and logo will show up on the topical event page under a 'Who's involved' heading.
+* a header image - this will show at the top of the page, next to the title and summary text
+* an event logo - this will show next to the description text
 
-1. Go back to the topical event page.
-2. Select the 'Organisations' tab.
-3. Select 'Make lead' next to the relevant organisations.
+Make sure you’ve correctly [formatted the images](/formatting-content/images-videos/formatting-images/) before you add them.
 
-## Add or edit an 'About' page
+To add an image:
 
-Use this page to give more detailed information on what the government is doing about the event.
+1. Select the ‘Images’ tab.
+2. Select ‘Add’ in the header image or event logo box.
+3. Choose your file and select ‘Upload’. If you’re going to use more than one image, make sure they all have a different file name.
+4. If it’s a header image, you can add a caption or image credit on the next screen. Leave it blank if you do not need to. Select ‘Save’ when you’re done.
+ 
+If the image requires cropping, it will say this when you go back to the ‘Images’ tab. 
 
-1. Select the 'About page' tab.
-2. Select 'Create new about page'.
-3. Add a name for the 'About' page. The name of the topical event page will automatically appear as the 'About' page title, so do not repeat this. 
-4. Add some 'Read more link text', following the guidance for [writing link text](/writing-to-gov-uk-standards/tone-of-voice/add-links/). The link text will appear below the summary on the main topical event page and direct users to the 'About' page.
-5. Complete the 'Summary' field using a maximum of 140 characters. Write it as a complete sentence with a full stop.
-6. Complete the 'Body' section.
-7. Select 'Save'. The draft will be published immediately.
+Select ‘Edit’ to crop the image or to edit the caption on header images.
 
 ## Tag a piece of content to the topical event page
 

--- a/app/publish-update-retire-content/promotional-social/topical-events.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events.md
@@ -171,4 +171,8 @@ You can change the order of featured content.
 1. Select the 'Featured' tab.
 2. Select 'Unfeature' to remove featured content from your topical events page.
 
+## Publish the draft
+
+{% include 'reusable-content/publish-draft.md' %}
+
 *[GDS]: Government Digital Service

--- a/app/publish-update-retire-content/promotional-social/topical-events.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events.md
@@ -43,12 +43,6 @@ Once you have that approval, then you can add a new page.
 
 {% include 'reusable-content/signon-account-whitehall.md' %}
 
-1. {% include 'reusable-content/whitehall-publisher.md' %}
-
-2. Select the 'More' tab.
-3. Select 'Topical events'.
-
-
 Once you’ve created a draft, you need to add the title, summary and description fields before you can save it.  
 
 ### If you’re creating a new topical event page
@@ -115,7 +109,7 @@ You can add:
 * a header image - this will show at the top of the page, next to the title and summary text
 * an event logo - this will show next to the description text
 
-Make sure you’ve correctly [formatted the images](/formatting-content/images-videos/formatting-images/) before you add them.
+Make sure you’ve correctly [formatted the images](/formatting-content/images/) before you add them.
 
 To add an image:
 


### PR DESCRIPTION
Updated the topical events guidance to reflect the new process for adding and editing them on Whitehall Publisher.

The process currently remains the same for 'old' topical events, so we've moved that guidance to a new page.

The process should become the same soon, so we can delete that new page then.

Also, fixed a typo in one of the 'Update settings' snippets.