### PR TITLE
Add table of contents to publish-standard.md

### DIFF
--- a/app/publish-update-retire-content/standard-content-types/publish-standard.md
+++ b/app/publish-update-retire-content/standard-content-types/publish-standard.md
@@ -8,6 +8,7 @@ title: Publish standard content types
 description: Learn how to publish and schedule standard content types, including force publishing and email notifications.
 lastUpdated:
 ---
+[[toc]]
 
 You need 'editor' permissions on Whitehall Publisher to publish content.
 


### PR DESCRIPTION
Table of contents added to make 'email notifications' more findable for users coming from previous manual page https://www.gov.uk/guidance/how-to-publish-on-gov-uk/email-notifications