### PR TITLE
Add footnotes and update 'Customs Duty' style guide entry

### DIFF
--- a/app/formatting-content/text-formatting/footnotes.md
+++ b/app/formatting-content/text-formatting/footnotes.md
@@ -8,6 +8,8 @@ description: Add footnotes to GOV.UK content with Govspeak Markdown code.
 lastUpdated:
 ---
 
+You can only add footnotes to HTML attachments and manuals.
+
 Avoid using footnotes in your content as much as possible. Footnotes are designed for reference in print, not webpages. 
 
 If you need to use a footnote, put [^n] into the sentence where you want to create the footnote, where ‘n’ is the number for the footnote.

--- a/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
+++ b/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
@@ -698,9 +698,9 @@ Lower case.
 
 Not curricula.
 
-### customs duty
+### Customs Duty
 
-Lower case.
+Upper case.
 
 ### customs union
 


### PR DESCRIPTION
Just two small changes.

1) Added a line to the footnotes guidance to explain they can only be used in HTML attachments and manuals, to avoid any confusion there.

2) Updated the 'Customs Duty' entry in the style guide A to Z to reflect changes requested by HMRC.