### PR TITLE
Added 'What's new' information

### DIFF
--- a/app/about-the-guidance/whats-new.md
+++ b/app/about-the-guidance/whats-new.md
@@ -8,4 +8,25 @@ description: Updates to the GOV.UK content and publishing guidance.
 lastUpdated:
 ---
 
-This page will be updated once this guidance enters into public beta.
+This page sets out all recent major updates to the GOV.UK content and publishing guidance.
+
+## May 2026
+
+| Date | Section | Update |
+| --------- | ----------- | ----------- |
+| 13 May | Entire guidance | The guidance site entered into public beta. The site combined 4 pre-existing manuals into a single place. There were also edits to reduce duplication and make the guidance easier to navigate. |
+
+## Get email updates about changes to the guidance
+
+[Sign up to receive email updates about changes to the GOV.UK content and publishing guidance](https://submit.forms.service.gov.uk/form/265492/gov-uk-content-and-publishing-guidance-updates).
+
+You do not need to sign up if you have access to Whitehall Publisher or other GOV.UK publishing applications, as you'll get these emails automatically.
+
+## Read about older updates
+
+If you want to read about updates made to older versions of this guidance, see the:
+
+- [archived updates page for ‘Content design: planning, writing and managing content’](https://webarchive.nationalarchives.gov.uk/ukgwa/20260501212920/https://www.gov.uk/guidance/content-design/updates)
+- [archived updates page for ‘How to publish on GOV.UK’](https://webarchive.nationalarchives.gov.uk/ukgwa/20260506204333/https://www.gov.uk/guidance/how-to-publish-on-gov-uk/updates)
+- [archived updates page for the style guide](https://webarchive.nationalarchives.gov.uk/ukgwa/20260409082354/https://www.gov.uk/guidance/style-guide/updates)
+- [archived updates page for ‘Support for government publishers’](https://webarchive.nationalarchives.gov.uk/ukgwa/20260427205506/https://www.gov.uk/guidance/contact-the-government-digital-service/updates)

--- a/app/formatting-content/text-formatting/calls-to-action.md
+++ b/app/formatting-content/text-formatting/calls-to-action.md
@@ -4,7 +4,7 @@ sectionKey: Formatting content
 eleventyNavigation:
   parent: Text formatting
 title: Calls to action
-description: Add calls to action to GOV.UK content with Govspeak Markdown code.
+description: Add a call to action to GOV.UK content with Govspeak Markdown code.
 lastUpdated:
 ---
 


### PR DESCRIPTION
Added content to the 'What's new' page to reflect the public beta opening.

Also, updated the metadescription for 'Calls to action' to include the singular 'call for action' so it's easier to find in the search bar.