### PR TITLE
Add dependabot cooldown and open pr limit [WHIT-3369]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 25


### PR DESCRIPTION
Adds a dependabot cooldown of 3 days and increases the upper limit on dependabot PRs to 25, as agreed in https://gov-uk.atlassian.net/browse/WHIT-3369