### PR TITLE
Add email update sign-up link to style guide

### DIFF
--- a/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
+++ b/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
@@ -9,6 +9,10 @@ description: See a list of the style points for all GOV.UK content, including ho
 lastUpdated:
 ---
 
+[Sign up to receive email updates about changes to the GOV.UK content and publishing guidance including the style guide](https://submit.forms.service.gov.uk/form/265492/gov-uk-content-and-publishing-guidance-updates).
+
+You do not need to sign up if you have access to Whitehall Publisher or other GOV.UK publishing applications, as you'll get these emails automatically.
+
 ## A
 
 ### A*, A*s

--- a/app/writing-to-gov-uk-standards/style-guides/index.md
+++ b/app/writing-to-gov-uk-standards/style-guides/index.md
@@ -11,8 +11,5 @@ lastUpdated:
 
 The Government Digital Service (GDS) style guides covers style points for content.
 
-[Sign up to receive email updates about changes to the GOV.UK content and publishing guidance including the style guide](https://submit.forms.service.gov.uk/form/265492/gov-uk-content-and-publishing-guidance-updates).
-
-You do not need to sign up if you have access to Whitehall Publisher or other GOV.UK publishing applications, as you'll get these emails automatically.
 
 *[GDS]: Government Digital Service

--- a/app/writing-to-gov-uk-standards/style-guides/index.md
+++ b/app/writing-to-gov-uk-standards/style-guides/index.md
@@ -11,4 +11,8 @@ lastUpdated:
 
 The Government Digital Service (GDS) style guides covers style points for content.
 
+[Sign up to receive email updates about changes to the GOV.UK content and publishing guidance including the style guide](https://submit.forms.service.gov.uk/form/265492/gov-uk-content-and-publishing-guidance-updates).
+
+You do not need to sign up if you have access to Whitehall Publisher or other GOV.UK publishing applications, as you'll get these emails automatically.
+
 *[GDS]: Government Digital Service

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -106,8 +106,8 @@ export default function(eleventyConfig) {
             text: "Privacy notice"
           },
           {
-            href: "/about-the-guidance",
-            text: "About the guidance"
+            href: "/about-the-guidance/whats-new",
+            text: "What's new"
           },
         ],
         html: 'Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-footer__link">Government Digital Service</a>.',


### PR DESCRIPTION
Added a sign-up link for email updates about GOV.UK content and publishing guidance.