### PR TITLE
Update 'What's new' page and homepage feature

### DIFF
--- a/app/about-the-guidance/whats-new.md
+++ b/app/about-the-guidance/whats-new.md
@@ -14,8 +14,8 @@ This page sets out all recent major updates to the GOV.UK content and publishing
 
 | Date | Section | Update |
 | --------- | ----------- | ----------- |
-| 20 May | Ask for a new organisation page | Updated the list of things to include in requests for new organisation pages. You should include the name and email address of a GOV.UK lead. |
-| 19  May | Publishing content | Updated the guidance on how to update URLs for already published pages. There's a new feature in Whitehall Publisher that makes this easier. |
+| 20 May | [Ask for a new organisation page](/accounts-support/make-content-requests/ask-new-organisation/) | Updated the list of things to include in requests for new organisation pages. You should include the name and email address of a GOV.UK lead. |
+| 19  May | [Standard content types](/publish-update-retire-content/standard-content-types/) | Updated the guidance on how to update URLs for already published pages. There's a new feature in Whitehall Publisher that makes this easier. |
 | 13 May | Entire guidance | The guidance site entered into public beta. The site combined 4 pre-existing manuals into a single place. There were also edits to reduce duplication and make the guidance easier to navigate. |
 
 ## Get email updates about changes to the guidance

--- a/app/about-the-guidance/whats-new.md
+++ b/app/about-the-guidance/whats-new.md
@@ -15,7 +15,7 @@ This page sets out all recent major updates to the GOV.UK content and publishing
 | Date | Section | Update |
 | --------- | ----------- | ----------- |
 | 20 May | [Ask for a new organisation page](/accounts-support/make-content-requests/ask-new-organisation/) | Updated the list of things to include in requests for new organisation pages. You should include the name and email address of a GOV.UK lead. |
-| 19  May | [Standard content types](/publish-update-retire-content/standard-content-types/) | Updated the guidance on how to update URLs for already published pages. There's a new feature in Whitehall Publisher that makes this easier. |
+| 19  May | [Standard content types](/publish-update-retire-content/standard-content-types/) | Updated the following pages with new guidance about how to update URLs: calls for evidence, case studies, consultations, detailed guides, document collections, fatality notices, news articles, publications, speeches and statistical data sets. There's a new feature in Whitehall Publisher that makes updating URLs easier. |
 | 13 May | Entire guidance | The guidance site entered into public beta. The site combined 4 pre-existing manuals into a single place. There were also edits to reduce duplication and make the guidance easier to navigate. |
 
 ## Get email updates about changes to the guidance

--- a/app/about-the-guidance/whats-new.md
+++ b/app/about-the-guidance/whats-new.md
@@ -14,6 +14,8 @@ This page sets out all recent major updates to the GOV.UK content and publishing
 
 | Date | Section | Update |
 | --------- | ----------- | ----------- |
+| 20 May | Ask for a new organisation page | Updated the list of things to include in requests for new organisation pages. You should include the name and email address of a GOV.UK lead. |
+| 19  May | Publishing content | Updated the guidance on how to update URLs for already published pages. There's a new feature in Whitehall Publisher that makes this easier. |
 | 13 May | Entire guidance | The guidance site entered into public beta. The site combined 4 pre-existing manuals into a single place. There were also edits to reduce duplication and make the guidance easier to navigate. |
 
 ## Get email updates about changes to the guidance

--- a/app/index.md
+++ b/app/index.md
@@ -7,9 +7,9 @@ description: Read the standards for digital content and find out how to use the 
 includeInBreadcrumbs: true
 eleventyExcludeFromCollections: false
 inverseMasthead: true
-whatsNewDate: 
-whatsNewHeadline: 
-whatsNew: 
+whatsNewDate: 20 May 2026
+whatsNewHeadline: Updated the guidance on requesting new organisation pages
+whatsNew: Read more about [recent changes to the guidance](/about-the-guidance/whats-new/).
 gridItems:
   - title: Style guides
     description: Style, spelling and grammar conventions for GOV.UK.


### PR DESCRIPTION
Updating the 'What's new' page to reflect these two recent changes:

https://github.com/alphagov/govuk-content-publishing-guidance/pull/131
https://github.com/alphagov/govuk-content-publishing-guidance/pull/132

Also updating the homepage to add a feature for recent updates.