### PR TITLE
Launch preparations: updates title suffix and removes external search block

### DIFF
--- a/_includes/layouts/main.njk
+++ b/_includes/layouts/main.njk
@@ -37,6 +37,5 @@
 {% block head %}
   {{ super() }}
   <meta name="google-site-verification" content="T789KqsmfvlTlaW2rvm5QJQBRYYL8yePTZWMJxMhIfo"/>
-  <meta name="robots" content="noindex, nofollow">
   <meta name="govuk:rendering-app" content="govuk-content-publishing-guidance">
 {% endblock %}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -47,7 +47,7 @@ export default function(eleventyConfig) {
   // Register the plugin
   eleventyConfig.addPlugin(govukEleventyPlugin, {
     homeKey: 'Home',
-    titleSuffix: 'Content and publishing guidance - GOV.UK',
+    titleSuffix: 'GOV.UK content and publishing guidance',
     showBreadcrumbs: true,
     stylesheets: [
       '/assets/styles.css'


### PR DESCRIPTION
This PR:

- updated the title suffix
- removed the block on external search indexing the site

> [!IMPORTANT]
> This should be merged a few hours before the new site is launched.  