### PR TITLE
Style guide layout changes

### DIFF
--- a/_includes/layouts/shared/style-guide-navigation.njk
+++ b/_includes/layouts/shared/style-guide-navigation.njk
@@ -1,0 +1,30 @@
+<nav role="navigation" aria-label="A to Z navigation">
+<ol class="style-a-z govuk-body" role="list">
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#a">A</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#b">B</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#c">C</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#d">D</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#e">E</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#f">F</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#g">G</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#h">H</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#i">I</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#j">J</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#k">K</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#l">L</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#m">M</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#n">N</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#o">O</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#p">P</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#q">Q</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#r">R</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#s">S</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#t">T</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#u">U</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#v">V</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#w">W</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#x">X</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#y">Y</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#z">Z</a></li>
+</ol>
+</nav>

--- a/_includes/layouts/style-guide.njk
+++ b/_includes/layouts/style-guide.njk
@@ -15,38 +15,6 @@
     {% include "layouts/shared/sub-navigation.njk" %}
     {% include "layouts/shared/document-header.njk" %}
 
-
-<nav role="navigation" aria-label="A to Z navigation">
-<ol class="style-a-z govuk-body" role="list">
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#a">A</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#b">B</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#c">C</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#d">D</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#e">E</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#f">F</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#g">G</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#h">H</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#i">I</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#j">J</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#k">K</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#l">L</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#m">M</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#n">N</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#o">O</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#p">P</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#q">Q</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#r">R</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#s">S</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#t">T</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#u">U</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#v">V</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#w">W</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#x">X</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#y">Y</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="#z">Z</a></li>
-</ol>
-</nav>
-
 <div class="style-guide">
     {{ appProseScope(content) if content }}
 </div>

--- a/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
+++ b/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
@@ -9,9 +9,15 @@ description: See a list of the style points for all GOV.UK content, including ho
 lastUpdated:
 ---
 
+{% include "layouts/shared/last-updated.njk" %}
+
+
 [Sign up to receive email updates about changes to the GOV.UK content and publishing guidance including the style guide](https://submit.forms.service.gov.uk/form/265492/gov-uk-content-and-publishing-guidance-updates).
 
 You do not need to sign up if you have access to Whitehall Publisher or other GOV.UK publishing applications, as you'll get these emails automatically.
+
+{% include "layouts/shared/style-guide-navigation.njk" %}
+
 
 ## A
 

--- a/app/writing-to-gov-uk-standards/style-guides/technical-a-to-z.md
+++ b/app/writing-to-gov-uk-standards/style-guides/technical-a-to-z.md
@@ -9,11 +9,17 @@ description: See a list of the style points for technical content on GOV.UK, inc
 lastUpdated: 
 ---
 
+{% include "layouts/shared/last-updated.njk" %}
+
+
 This section only covers style conventions for technical content on GOV.UK.
 
 If you cannot find something, look at the [style guide A to Z](/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/) which covers style conventions for all content on GOV.UK.
 
 If you want to suggest a change, read the [guidance on how to use the style guide](/writing-to-gov-uk-standards/style-guides/how-to-use/).
+
+
+{% include "layouts/shared/style-guide-navigation.njk" %}
 
 
 ## A


### PR DESCRIPTION
This pull request:

- moves the A to Z navigation outside of the layout
- puts the A to Z navigation into a include
- adds the A to Z navigation and last updated includes into the 2 style guide pages