### PR TITLE
Add 'Ask for history mode to be removed' guidance

### DIFF
--- a/_includes/reusable-content/remove-history-mode.md
+++ b/_includes/reusable-content/remove-history-mode.md
@@ -1,3 +1,1 @@
-If you select 'Create new edition' and you get a message telling you that the 'document is in history mode', you cannot update it without help from the Government Digital Service (GDS). [Ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you want to remove history mode.
-
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+If you select 'Create new edition' and you get a message telling you that the 'document is in history mode', you cannot update it without [asking the Government Digital Service (GDS) to remove history mode](https://support.publishing.service.gov.uk/content_advice_request/new).

--- a/app/about-the-guidance/whats-new.md
+++ b/app/about-the-guidance/whats-new.md
@@ -10,6 +10,13 @@ lastUpdated:
 
 This page sets out all recent major updates to the GOV.UK content and publishing guidance.
 
+## June 2026
+
+| Date | Section | Update |
+| --------- | ----------- | ----------- |
+| 1 June | [Ask for history mode to be removed](/accounts-support/make-content-requests/ask-history-mode/) | Added this as a new page. |
+
+
 ## May 2026
 
 | Date | Section | Update |

--- a/app/accounts-support/make-content-requests/ask-history-mode.md
+++ b/app/accounts-support/make-content-requests/ask-history-mode.md
@@ -1,0 +1,49 @@
+---
+layout: landing-page
+sectionKey: Accounts and support
+order: 9
+eleventyNavigation:
+  parent: Make content requests
+title: Ask for history mode to be removed
+description: Ask GDS to turn off history mode on Whitehall content.
+lastUpdated:
+---
+
+If Whitehall content is in ‘history mode’, you cannot update or unpublish it.
+
+You can ask the Government Digital Service (GDS) to:
+
+- turn off history mode
+- change the ‘associated government’ of content in history mode, if the content was actually first published under a different government
+
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request.
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. Speak to your GOV.UK lead or managing editor if you want access.
+
+> [!NOTE]
+> Read more about [when history mode will be applied to content](/writing-to-gov-uk-standards/plan-manage-content/retire-content/#when-history-mode-gets-applied).
+
+## Asking GDS to turn off history mode
+
+GDS can turn off history mode if you need to:
+
+- fix an error like a broken link or a typo - they will turn history mode back on when you’re done
+- add a response to a consultation or a call for evidence - if it’s a response from a new government, history mode can be kept off
+- remove an associated minister if they should not be tagged to the current content - this may be the thing putting the content into history mode
+
+GDS cannot turn off history mode if you only want to update the content to keep it current.
+
+If you want to see all the content you have that’s in history mode, go to the ‘Documents’ tab in Whitehall Publisher. Filter the search results as needed, and then select ‘Export as CSV’. The CSV file will have a column saying if the content has history mode applied.
+
+### If GDS cannot turn off history mode
+
+If you have content in history mode that’s still current, consider if it should be in a different content type that will not go into history mode.
+
+For example, if it has current guidance for users, consider using a [detailed guide](/publish-update-retire-content/standard-content-types/detailed-guides/) or a ['guidance' or 'statutory guidance' publication](/publish-update-retire-content/standard-content-types/publications/). You could then either:
+
+- create a new version of the content with an explanation that it’s an updated version of the content in history mode, and ask GDS to withdraw the content in history mode
+- ask GDS to change the existing content into the new content type, if you chose the wrong content type initially
+
+If you need to add new attachments to content in history mode, consider creating a new [document collection](/publish-update-retire-content/standard-content-types/document-collections/). You could then create separate publications for the new attachments and group the old and new content together in the document collection.
+
+*[GDS]: Government Digital Service

--- a/app/index.md
+++ b/app/index.md
@@ -7,8 +7,8 @@ description: Read the standards for digital content and find out how to use the 
 includeInBreadcrumbs: true
 eleventyExcludeFromCollections: false
 inverseMasthead: true
-whatsNewDate: 20 May 2026
-whatsNewHeadline: Updated the guidance on requesting new organisation pages
+whatsNewDate: 1 June 2026
+whatsNewHeadline: Added new guidance about asking to remove history mode
 whatsNew: Read more about [recent changes to the guidance](/about-the-guidance/whats-new/).
 gridItems:
   - title: Style guides

--- a/app/publish-update-retire-content/standard-content-types/case-studies.md
+++ b/app/publish-update-retire-content/standard-content-types/case-studies.md
@@ -70,10 +70,11 @@ After saving the page, you can add images and attachments.
 8. {% include 'reusable-content/change-notes.md' %}
 9. Select the 'Save' button at the bottom of the page.
 
+You can now edit the images and attachments.
+
+
 {% include 'reusable-content/remove-history-mode.md' %}
 
-
-You can now edit the images and attachments.
 
 ## Add or remove images
 

--- a/app/publish-update-retire-content/standard-content-types/statistics.md
+++ b/app/publish-update-retire-content/standard-content-types/statistics.md
@@ -112,13 +112,15 @@ When the statistics publication is published, the announcement will disappear fr
 
 1. Select the 'Documents' tab in Whitehall Publisher. This will bring up a list of publications. Use the filters to find yours.
 2. Select 'View' next to the publication.
-3. Select the 'Edit' button.
+3. Select the 'Create new edition' button.
 4. Make your changes.
 5. {% include 'reusable-content/political-heading.md' %}
 
 6. {% include 'reusable-content/change-notes.md' %}
 7. Select the 'Save' button at the bottom of the page.
 8. Select 'Submit for 2nd eyes'. This will allow another editor to [review your document](/publish-update-retire-content/standard-content-types/review-standard/) and then they can publish or schedule it.
+
+{% include 'reusable-content/remove-history-mode.md' %}
 
 ## Edit a statistics announcement title, summary, organisation or topic
 

--- a/app/writing-to-gov-uk-standards/plan-manage-content/retire-content.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/retire-content.md
@@ -139,9 +139,6 @@ Before a general election, affected organisations will be asked by GDS to do a h
 + see what content will go into history mode if the government changes 
 + prevent content from going into history mode if you think there is a problem
 
-If you think content should be removed from history mode after it’s been applied, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new).
-
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
-
+If you think content should no longer be in history mode, [ask GDS to remove history mode](/accounts-support/make-content-requests/ask-history-mode/).
 
 *[GDS]: Government Digital Service


### PR DESCRIPTION
Added a new page about asking for history mode to be removed from content.

Updated the 'What's new' page and the homepage to reflect this change.

Updated the 'Retire outdated content' page and the history mode snippet to point towards this new page.

Added the history mode snippet to the 'Statistics' page and corrected a small error.

Swapped around some paragraphs on the 'Case studies' page for clarity.