### PR TITLE
Add redirect template

### DIFF
--- a/app/redirect.njk
+++ b/app/redirect.njk
@@ -1,0 +1,37 @@
+---js
+{
+  pagination: {
+    data: "collections.all",
+    size: 1,
+    alias: "redirect",
+    before: function (data) {
+      return data.reduce((redirects, page) => {
+        if (Array.isArray(page.data.redirect_from)) {
+          for (let url of page.data.redirect_from) {
+            redirects.push({ to: page.url, from: url });
+          }
+        } else if (typeof page.data.redirect_from === 'string') {
+          redirects.push({ to: page.url, from: page.data.redirect_from });
+        }
+        return redirects;
+      }, []);
+    },
+    addAllPagesToCollections: false,
+  },
+  permalink: "{{ redirect.from }}/index.html",
+  eleventyExcludeFromCollections: true,
+}
+---
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8" />
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ redirect.to | url }}" />
+  <script>
+    location = '{{ redirect.to | url }}';
+  </script>
+  <meta http-equiv="refresh" content="0; url={{ redirect.to | url }}" />
+  <meta name="robots" content="noindex" />
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ redirect.to | url }}">Continue to redirected page</a>
+</html>


### PR DESCRIPTION
This pull request adds a template to allow pages to be redirected if, for example, a slug/URL is changed. This is an MVP approach.

This means by adding `redirect_from:` to destination page, the URL named will then redirect on to the page where this string is added in the front matter.

For example, if the slug of a page was `/writing-to-gov-uk-standards/tone-of-voice/clear-language` and then the folder it was in was changed to `/writing-to-gov-uk-standards/writing-for-gov-uk/clear-language`, in the front matter of the `clear-language.md` file, you'd add: `redirect_from: /writing-to-gov-uk-standards/tone-of-voice/clear-language`. This will redirect users from the old URL to the new URL.

You can also add multiple `redirect_from` URLs like the following: `redirect_from: [/old-url/page, /some-other-page]`.