### PR TITLE
Add examples of content types

### DIFF
--- a/app/publish-update-retire-content/organisations-people/groups.md
+++ b/app/publish-update-retire-content/organisations-people/groups.md
@@ -16,6 +16,9 @@ Policy advisory groups are panels of people who advise on policy development, ty
 
 Other groups include units, teams and committees within, set up or sponsored by your organisation, and who carry out specific areas of work.
 
+> [!NOTE]
+> See an [example of a group page on GOV.UK](https://www.gov.uk/government/groups/council-for-sustainable-business).
+
 ## When you need a group page
 
 Group pages should only be set up when there's:

--- a/app/publish-update-retire-content/organisations-people/organisations.md
+++ b/app/publish-update-retire-content/organisations-people/organisations.md
@@ -106,7 +106,7 @@ When choosing links, consider:
 * balancing mainstream and specialist user needs - the [guidance on planning new content](/writing-to-gov-uk-standards/plan-manage-content/plan-new-govuk-content/) includes more information about the difference between mainstream and specialist content
 * seasonal trends (for example applications for study visas or fishing rod licences)
 
-See [a good example of a service priority organisation page](https://www.gov.uk/government/organisations/companies-house). 
+See [an example of a service priority organisation page](https://www.gov.uk/government/organisations/companies-house). 
 
 ### Choosing links for a news priority layout
 
@@ -129,7 +129,7 @@ Do not include links to content that's already featured elsewhere on your organi
 
 Do not include campaign sites unless there's evidence of significant user demand.
 
-See [a good example of a news priority organisation page](https://www.gov.uk/government/organisations/department-for-energy-security-and-net-zero). 
+See [an example of a news priority organisation page](https://www.gov.uk/government/organisations/department-for-energy-security-and-net-zero). 
 
 ## The 'What we do' section and 'About us' page
 

--- a/app/publish-update-retire-content/organisations-people/people-roles.md
+++ b/app/publish-update-retire-content/organisations-people/people-roles.md
@@ -23,7 +23,10 @@ Links to these pages appear:
 
 People and their roles are covered by 2 separate sections of Whitehall Publisher. You need the person first, then you can assign a role to them by editing the role.
 
-To work on people or role pages, you'll need a [Signon account with access to Whitehall Publisher](/accounts-support/manage-accounts-training/publishing-accounts-permissions/). 
+To work on people or role pages, you'll need a [Signon account with access to Whitehall Publisher](/accounts-support/manage-accounts-training/publishing-accounts-permissions/).
+
+> [!NOTE]
+> See an [example of a people page on GOV.UK](https://www.gov.uk/government/people/aarti-thakor) and an [example of a role page on GOV.UK](https://www.gov.uk/government/ministers/secretary-of-state-for-transport).
 
 ## When to add and update people and role pages
 

--- a/app/publish-update-retire-content/organisations-people/worldwide.md
+++ b/app/publish-update-retire-content/organisations-people/worldwide.md
@@ -22,8 +22,8 @@ Worldwide pages collect information about the UK's government work abroad. They 
 
 World location news pages can either be for:
 
-* worldwide locations, such as '[Country] and the UK' 
-* international delegations, such as 'UK and [delegation name]'
+* worldwide locations, such as the ['France and the UK' news page on GOV.UK](https://www.gov.uk/world/france/news)
+* international delegations, such as the ['UK Mission to the United Nations (New York)' news page on GOV.UK](https://www.gov.uk/world/uk-mission-to-the-united-nations-new-york)
 
 The 2 types of pages are very similar and are updated in the same way.
 
@@ -132,6 +132,9 @@ If you want to update an existing translation:
 Worldwide organisation pages are for information about help and services users can access abroad through UK government organisations. They also present the public face of the organisation and its work.
 
 You usually only need to make changes to existing worldwide organisations. Do not create a new worldwide organisation page unless you have permission from your managing editor or GOV.UK lead. 
+
+> [!NOTE]
+> See an [example of a worldwide organisation page on GOV.UK](https://www.gov.uk/world/organisations/british-embassy-paris).
 
 ### Add a new world organisation page
 
@@ -322,6 +325,9 @@ There's a navigation page for each country and territory.
 - to edit the title, sections or description of an existing page
 
 You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+
+> [!NOTE]
+> See an [example of a help and services navigation page on GOV.UK](https://www.gov.uk/world/france).
  
 ### Tag content
 

--- a/app/publish-update-retire-content/other-content-types/find-my-nearest.md
+++ b/app/publish-update-retire-content/other-content-types/find-my-nearest.md
@@ -10,7 +10,7 @@ lastUpdated:
 
 'Find my nearest' pages are mainstream pages which allow users to search for a service near them.
 
-View an [example of a 'find my nearest' page](https://www.gov.uk/find-theory-test-centre).
+See an [example of a 'find my nearest' page](https://www.gov.uk/find-theory-test-centre).
 
 When a user enters a postcode, they get search results which show them their nearest local service.
 

--- a/app/publish-update-retire-content/other-content-types/local-transaction.md
+++ b/app/publish-update-retire-content/other-content-types/local-transaction.md
@@ -12,7 +12,7 @@ Local transaction pages link users to services and information provided by their
 
 When a user enters a postcode, they're told the related council and given a link to a relevant page on their website.
 
-View an [example of a local transaction page](https://www.gov.uk/pay-council-tax).
+See an [example of a local transaction page](https://www.gov.uk/pay-council-tax).
 
 ## Add or remove a local transaction page
 

--- a/app/publish-update-retire-content/other-content-types/manuals.md
+++ b/app/publish-update-retire-content/other-content-types/manuals.md
@@ -38,7 +38,8 @@ Do not use them for:
 * PDFs or documents that are published elsewhere on GOV.UK
 * internal guidance, unless there's a legal requirement to do so (for example HMRC manuals)
 
-View a [good example of a manual](https://www.gov.uk/guidance/convert-to-an-academy-information-for-schools).
+> [!NOTE]
+> See an [example of a manual](https://www.gov.uk/guidance/convert-to-an-academy-information-for-schools).
 
 ## Get approval to create a new manual
 

--- a/app/publish-update-retire-content/other-content-types/specialist-finders.md
+++ b/app/publish-update-retire-content/other-content-types/specialist-finders.md
@@ -26,7 +26,8 @@ Do not use them for:
 + grouping pages that contain different types of content – these are more suited to [topic pages](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/plan-manage-content/organise-group-govuk-content/)
 + collections that will have fewer than 100 documents and will not be used or updated regularly – these are more suited to [document collections](/publish-update-retire-content/standard-content-types/document-collections/)
 
-See a [good example of a specialist finder](https://www.gov.uk/algorithmic-transparency-records).
+> [!NOTE]
+> See an [example of a specialist finder](https://www.gov.uk/algorithmic-transparency-records).
 
 ## Ask for a new specialist finder
 

--- a/app/publish-update-retire-content/promotional-social/blogs.md
+++ b/app/publish-update-retire-content/promotional-social/blogs.md
@@ -24,6 +24,8 @@ Compared to newsletters, they can help make information accessible, they are eas
 - routinely get more traffic than newsletters
 - allow users to sign up for email updates
 
+See an [example of a blog site](https://insidegovuk.blog.gov.uk/).
+
 ## When to use a blog
 
 Blogs are not published on the main GOV.UK site, but on the blog.gov.uk subdomain through a WordPress platform.

--- a/app/publish-update-retire-content/standard-content-types/calls-for-evidence.md
+++ b/app/publish-update-retire-content/standard-content-types/calls-for-evidence.md
@@ -24,6 +24,9 @@ There could be legal consequences if you use a call for evidence content type wh
 
 Check the [consultation principles](https://www.gov.uk/government/publications/consultation-principles-guidance) or speak to your legal advisors if you're not sure whether you're doing a consultation or a call for evidence.
 
+> [!NOTE]
+> See an [example of a call for evidence on GOV.UK](https://www.gov.uk/government/calls-for-evidence/solar-on-car-parks-and-electric-vehicle-charging).
+
 ## How calls for evidence work
 
 Calls for evidence stay on the same page of GOV.UK, including when they are closed.

--- a/app/publish-update-retire-content/standard-content-types/case-studies.md
+++ b/app/publish-update-retire-content/standard-content-types/case-studies.md
@@ -21,7 +21,7 @@ Use case studies for real examples that help users understand someone's personal
 They can be either a first person account or a third person account with quotes from the person it's about. They can be in video form.
 
 > [!NOTE]
-> See a [good example of a case study on GOV.UK](https://www.gov.uk/government/case-studies/how-the-home-offices-immigration-technology-department-reduced-its-cloud-costs-by-40).
+> See an [example of a case study on GOV.UK](https://www.gov.uk/government/case-studies/how-the-home-offices-immigration-technology-department-reduced-its-cloud-costs-by-40).
 
 Do not create a case study if:
 

--- a/app/publish-update-retire-content/standard-content-types/consultations.md
+++ b/app/publish-update-retire-content/standard-content-types/consultations.md
@@ -23,6 +23,9 @@ Do not use the content type for:
 - documents that should be added to an existing consultation (such as supporting or outcome documents)
 - informal 'consultations' like surveys
 
+> [!NOTE]
+> See an [example of a consultation on GOV.UK](https://www.gov.uk/government/consultations/review-of-the-default-fund-charge-cap-and-standardised-cost-disclosure).
+
 ## How consultations work
 
 Consultations stay on the same page of GOV.UK, including when they're closed.

--- a/app/publish-update-retire-content/standard-content-types/detailed-guides.md
+++ b/app/publish-update-retire-content/standard-content-types/detailed-guides.md
@@ -19,6 +19,9 @@ Use this type for content that is regularly updated, for example if the process 
 
 Content containing background information about why a user needs to complete a task or the history behind it should be in a policy paper [publication](/publish-update-retire-content/standard-content-types/publications/).
 
+> [!NOTE]
+> See an [example of a detailed guide on GOV.UK](https://www.gov.uk/guidance/cites-imports-and-exports).
+
 ## Create a draft
 
 {% include 'reusable-content/signon-account-whitehall.md' %}

--- a/app/publish-update-retire-content/standard-content-types/document-collections.md
+++ b/app/publish-update-retire-content/standard-content-types/document-collections.md
@@ -33,6 +33,9 @@ Do not create a collection:
 - for a single piece of content
 - for editions of the same publication (these should be multiple attachments on a single publication page)
 
+> [!NOTE]
+> See an [example of a document collection on GOV.UK](https://www.gov.uk/government/collections/national-driving-and-riding-standards).
+
 ## Create a draft
 
 {% include 'reusable-content/signon-account-whitehall.md' %}

--- a/app/publish-update-retire-content/standard-content-types/fatality-notices.md
+++ b/app/publish-update-retire-content/standard-content-types/fatality-notices.md
@@ -22,7 +22,7 @@ Do not publish a news story which duplicates the fatality notice.
 If there were multiple deaths in one incident, create a fatality notice for the whole incident rather than for each individual death.
 
 > [!NOTE]
-> See a [good example of a fatality notice](https://www.gov.uk/government/fatalities/sergeant-duane-baz-barwood-raf-killed-in-iraq).
+> See an [example of a fatality notice on GOV.UK](https://www.gov.uk/government/fatalities/sergeant-duane-baz-barwood-raf-killed-in-iraq).
 
 ## Create a draft
 

--- a/app/publish-update-retire-content/standard-content-types/news-articles.md
+++ b/app/publish-update-retire-content/standard-content-types/news-articles.md
@@ -34,27 +34,32 @@ There are different types of news articles. Make sure you choose the right type.
       <th scope="col" class="govuk-table__header">Content type</th>
       <th scope="col" class="govuk-table__header">What to use it for</th>
       <th scope="col" class="govuk-table__header">What not to use it for</th>
+      <th scope="col" class="govuk-table__header">Example</th>
     </tr>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Government response</th>
       <td class="govuk-table__cell"><p class="govuk-body">Government statements produced in response to media coverage by your organisation's press team. For example, rebuttals or 'myth busters'. These are usually short and to the point, consisting of a quotation with no headings.</p></td>
       <td class="govuk-table__cell"><p class="govuk-body">Statements issued to Parliament, speeches, press articles and letters to newspapers written by ministers. Use the <a href="/publish-update-retire-content/standard-content-types/speeches/" class="govuk-link">speech type</a> for all of these instead.</p></td>
+      <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/news/cargo-on-direct-flights-from-bangladesh-to-the-uk" class="govuk-link">Example of a government response on GOV.UK</a>.</p></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">News story</th>
       <td class="govuk-table__cell"><p class="govuk-body">News content written only for GOV.UK which users need, can act on, would expect to get directly from the government and cannot get from other sources. For example, the opening of a government grant scheme or a change to public services that affects public sector employees. The content should be self-contained so it can be deleted from the site without affecting anything else.</p></td>
       <td class="govuk-table__cell"><p class="govuk-body">Duplication of press releases or <a href="/publish-update-retire-content/standard-content-types/fatality-notices/" class="govuk-link">fatality notices</a>.</p></td>
+      <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/news/ofsted-inspections-to-be-done-remotely-until-half-term" class="govuk-link">Example of a news story on GOV.UK</a>.</p></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Press release</th>
       <td class="govuk-table__cell"><p class="govuk-body">Unedited press releases as sent to the media (with additional notes at the end under a ‘Background’ heading). Also, official statements by an organisation spokesperson or by a minister (apart from parliamentary statements).</p></td>
       <td class="govuk-table__cell"><p class="govuk-body">Ministerial statements issued to Parliament. Use the <a href="/publish-update-retire-content/standard-content-types/speeches/" class="govuk-link">speech type</a> instead.</p></td>
+      <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/news/more-than-22-million-people-in-uk-receive-first-dose-of-covid-19-vaccine" class="govuk-link">Example of a press release on GOV.UK</a>.</p></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">World news story</th>
       <td class="govuk-table__cell"><p class="govuk-body">Announcements specific to one or more world locations. For example, news related to a British embassy.</p></td>
       <td class="govuk-table__cell"><p class="govuk-body">Duplication of another government organisation's news story.</p></td>
+      <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/news/king-charles-iii-birthday-celebrates-uk-nations-and-cambodia-ties" class="govuk-link">Example of a world news story on GOV.UK</a>.</p></td>
     </tr>
  </tbody>
 </table>

--- a/app/publish-update-retire-content/standard-content-types/publications.md
+++ b/app/publish-update-retire-content/standard-content-types/publications.md
@@ -49,97 +49,116 @@ There are different types of publications. Make sure you choose the right type, 
       <th scope="col" class="govuk-table__header">Content type</th>
       <th scope="col" class="govuk-table__header">What to use it for</th>
       <th scope="col" class="govuk-table__header">What not to use it for</th>
+      <th scope="col" class="govuk-table__header">Example</th>
     </tr>
 <tbody class="govuk-table__body">
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Corporate report</th>
       <td class="govuk-table__cell">Publications about your organisation as a corporate entity. This includes accounts, annual reports, business plans, performance and efficiency reviews and structural reform plans.</td>
       <td class="govuk-table__cell">Publications about what your organisation does, like strategy documents. Use the policy paper type instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/iiac-annual-report-2019-to-2020--2" class="govuk-link">Example of a corporate response on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Correspondence</th>
       <td class="govuk-table__cell">Correspondence created by your organisation or ministers. This includes announcements, letters, responses and statements. It also includes bulletins, circulars, e-bulletins and newsletters.</td>
       <td class="govuk-table__cell">Formal decision letters from tribunals, regulators or adjudicators. Use the decision type instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/update-to-hasc-on-windrush-28-april-2020" class="govuk-link">Example of correspondence on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Decision</th>
       <td class="govuk-table__cell">Formal decisions made by tribunals, regulators or adjudicators that need to be published for legal reasons or because they relate to significant local or national issues.</td>
       <td class="govuk-table__cell">Responses to consultations and calls for evidence. Use the <a href="/publish-update-retire-content/standard-content-types/consultations/" class="govuk-link">consultation type</a> or <a href="/publish-update-retire-content/standard-content-types/calls-for-evidence/" class="govuk-link">call for evidence type</a> instead. Also, press announcements about the decision. Use the <a href="/publish-update-retire-content/standard-content-types/news-articles" class="govuk-link">news article type</a> instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/medical-devices-given-exceptional-use-authorisations" class="govuk-link">Example of a decision on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Form</th>
       <td class="govuk-table__cell">Forms or pro forma documents that need to be completed by the user. The page can also include guidance on how to fill in the form.</td>
       <td class="govuk-table__cell">Anything that is not a form or guidance about filling in a form.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/pet-travel-declaration-for-the-non-commercial-movement-of-animals" class="govuk-link">Example of a form on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Freedom of information (FOI) release</th>
       <td class="govuk-table__cell">Response to FOI requests.</td>
       <td class="govuk-table__cell">Anything that is not a response to an FOI request.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/climate-related-job-posts-at-the-security-industry-authority" class="govuk-link">Example of a FOI release on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Guidance</th>
       <td class="govuk-table__cell">Non-statutory guidance publications like handbooks or other documents that offer advice. Also, guidance material that has been produced as a standalone hard copy document rather than a web original document.</td>
       <td class="govuk-table__cell">Statutory guidance. Use the statutory guidance type instead. Guidance about completing a form. Attach it to the same publication as the form itself.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/charity-fundraising-a-guide-to-trustee-duties-cc20" class="govuk-link">Example of guidance on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Impact assessment</th>
       <td class="govuk-table__cell">Documents that assess the impact of new initiatives or changes to legislation. This includes impact assessments, equality impact assessments and equality impact analyses.</td>
       <td class="govuk-table__cell">Impact assessments related to policy papers already published on GOV.UK. Attach it to the same publication as the policy paper.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/tax-changes-for-short-term-business-visitors" class="govuk-link">Example of an impact assessment on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Independent report</th>
       <td class="govuk-table__cell">Reports commissioned by the government but written by non-government organisations. This includes independent enquiries, investigations and reviews.	</td>
       <td class="govuk-table__cell">Reports written by the government. Use the policy paper type or research and analysis type instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/priority-groups-for-coronavirus-covid-19-vaccination-advice-from-the-jcvi-30-december-2020" class="govuk-link">Example of an independent report on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">International treaty</th>
       <td class="govuk-table__cell">Treaties and memoranda of understanding between the UK and other nations.</td>
       <td class="govuk-table__cell">Anything that is not an international treaty or memoranda of understanding.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/usa-tax-treaties" class="govuk-link">Example of an international treaty on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Map</th>
       <td class="govuk-table__cell">Drawn maps and geographical data.</td>
       <td class="govuk-table__cell">Anything that is not a map or geographical data.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/england-coast-path-overview-of-progress" class="govuk-link">Example of a map on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Notice</th>
       <td class="govuk-table__cell">Permit and licence applications that have to be published temporarily in a public space so users can view, comment or lodge an objection.</td>
       <td class="govuk-table__cell">Anything that is not a permit or licence application.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/walton-farms-limited-application-made-to-abstract-take-water" class="govuk-link">Example of a notice on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Policy paper</th>
       <td class="govuk-table__cell">Publications that explain the government’s position on something. This includes action plans, implementation plans, operational plans, strategies and white papers. The page can also include any related impact assessments.</td>
       <td class="govuk-table__cell">Publications that include instructions about how to carry out a task. Use the guidance type instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/covid-19-vaccination-uptake-plan" class="govuk-link">Example of a policy paper on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Promotional material</th>
       <td class="govuk-table__cell">Fact sheets, leaflets, marketing collateral and posters.</td>
       <td class="govuk-table__cell">Letters or other correspondence. Use the correspondence type instead. Also, press releases. Use the <a href="/publish-update-retire-content/standard-content-types/news-articles" class="govuk-link">news article type</a> instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/flu-vaccination-leaflets-and-posters" class="govuk-link">Example of promotional material on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Regulation</th>
       <td class="govuk-table__cell">Regulations imposed by independent regulatory authorities, like Ofsted or the Military Aviation Authority.</td>
       <td class="govuk-table__cell">Statutory guidance describing requirements that are mandatory by law. Use the statutory guidance type instead. Also, non-statutory guidance like handbooks and other documents that offer advice. Use the guidance type instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/notice-of-authorised-amendments-naa-reference-table" class="govuk-link">Example of a regulation on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Research and analysis</th>
       <td class="govuk-table__cell">Analyses, evaluations, research reports and surveys. They can be conducted by government, commissioned by government or independent of government.	</td>
       <td class="govuk-table__cell">Responses to consultations and calls for evidence. Use the <a href="/publish-update-retire-content/standard-content-types/consultations/" class="govuk-link">consultation type</a> or <a href="/publish-update-retire-content/standard-content-types/calls-for-evidence/" class="govuk-link">call for evidence type</a> instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/heat-training-grant-2025-mid-scheme-review-heat-pump-installers" class="govuk-link">Example of research and analysis on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Standard</th>
       <td class="govuk-table__cell">Requirements, specifications, guidelines or patterns that can be consistently applied to products, processes and services within government.</td>
       <td class="govuk-table__cell">Any standards that are not about products, processes or services within government.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/skills-england-standards-for-official-statistics" class="govuk-link">Example of a standard on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Statutory guidance</th>
       <td class="govuk-table__cell">Guidance that relevant users must follow.</td>
       <td class="govuk-table__cell">Non-statutory guidance. Use the guidance type instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/wild-birds-licence-to-kill-or-take-for-conservation-purposes-gl40" class="govuk-link">Example of statutory guidance on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Transparency data</th>
       <td class="govuk-table__cell">Data that organisations are routinely required to make available to the public. This includes departmental spending and ministerial expenses.</td>
       <td class="govuk-table__cell">Responses to FOI requests. Use the FOI release type instead. Also, information that is not going to be published on a regular and ongoing basis. Use the <a href="/publish-update-retire-content/standard-content-types/statistical-data-sets/" class="govuk-link">statistical data set type</a> instead.</td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/covid-19-loan-guarantee-schemes-repayment-data-march-2026" class="govuk-link">Example of transparency data on GOV.UK</a>.</p></td>
     </tr>
 </tbody>
 </table>

--- a/app/publish-update-retire-content/standard-content-types/publications.md
+++ b/app/publish-update-retire-content/standard-content-types/publications.md
@@ -56,7 +56,7 @@ There are different types of publications. Make sure you choose the right type, 
       <th scope="row" class="govuk-table__header">Corporate report</th>
       <td class="govuk-table__cell">Publications about your organisation as a corporate entity. This includes accounts, annual reports, business plans, performance and efficiency reviews and structural reform plans.</td>
       <td class="govuk-table__cell">Publications about what your organisation does, like strategy documents. Use the policy paper type instead.</td>
-       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/iiac-annual-report-2019-to-2020--2" class="govuk-link">Example of a corporate response on GOV.UK</a>.</p></td>
+       <td class="govuk-table__cell"><p class="govuk-body"><a href="https://www.gov.uk/government/publications/iiac-annual-report-2019-to-2020--2" class="govuk-link">Example of a corporate report on GOV.UK</a>.</p></td>
     </tr>
   <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Correspondence</th>

--- a/app/publish-update-retire-content/standard-content-types/speeches.md
+++ b/app/publish-update-retire-content/standard-content-types/speeches.md
@@ -42,6 +42,15 @@ Before you start, decide whether the speech should be marked as:
 - oral statement to Parliament
 - authored article
 
+See an:
+
+- [example of a transcript on GOV.UK](https://www.gov.uk/government/speeches/foreign-secretarys-keynote-speech-at-the-global-partnerships-conference-19-may-2026)
+- [example of draft text on GOV.UK](https://www.gov.uk/government/speeches/registered-charity-status-a-social-contract)
+- [example of speaking notes on GOV.UK](https://www.gov.uk/government/speeches/presentation-by-the-uk-chairperson-of-the-osce-security-committee-ambassador-neil-bush)
+- [example of a written statement on GOV.UK](https://www.gov.uk/government/speeches/light-dues-for-the-year-2021-to-2022)
+- [example of an oral statement on GOV.UK](https://www.gov.uk/government/speeches/strengthening-our-health-protection-at-the-border)
+- [example of an authored article on GOV.UK](https://www.gov.uk/government/speeches/minister-falconer-article-on-syria-anniversary-december-2025)
+
 ## Create a draft
 
 ### If you're creating a new speech

--- a/app/publish-update-retire-content/standard-content-types/statistical-data-sets.md
+++ b/app/publish-update-retire-content/standard-content-types/statistical-data-sets.md
@@ -20,6 +20,10 @@ Use statistical data sets for data that you both:
 
 For data sets you publish less frequently or with analysis, use [statistics content](/publish-update-retire-content/standard-content-types/statistics/) instead.
 
+> [!NOTE]
+> See an [example of a statistical data set on GOV.UK](https://www.gov.uk/government/statistical-data-sets/companies-house-management-information-identity-verification-january-to-march-2026).
+
+
 ## Create a draft
 
 {% include 'reusable-content/signon-account-whitehall.md' %}

--- a/app/publish-update-retire-content/standard-content-types/statistics.md
+++ b/app/publish-update-retire-content/standard-content-types/statistics.md
@@ -29,6 +29,9 @@ You must create a statistics publication joined to your statistics announcement.
 
 The publication should contain the statistics described in the announcement or link to them if they're published on an external website. 
 
+> [!NOTE]
+> See an [example of a statistics publication on GOV.UK](https://www.gov.uk/government/statistics/cold-weather-payment-estimates-2020-to-2021).
+
 ## How far in advance to publish statistics announcements
 
 Publish a statistics announcement 12 months before the release date. If you do not know about the statistics 12 months in advance, announce them as soon as possible.


### PR DESCRIPTION
Added examples for each content type if there were none before.

When pages already had examples, sometimes updated the wording so that link text is more standardised across site.

Could not add an example of a statistics announcement as they unpublish themselves regularly, but we link to the release calendar which users can look through for current examples.

No changes needed for corporate information pages, as there were either already examples or templates that can be used.

Minor change overall so no 'What's new' update needed.