### PR TITLE
Update code example formatting

### DIFF
--- a/app/formatting-content/text-formatting/tables.md
+++ b/app/formatting-content/text-formatting/tables.md
@@ -220,11 +220,13 @@ You need to:
 
 For example, here is the markdown for a table showing the number of different animals in 3 different farms.
 
-`| | Woodchurch | Moat | Jenkey |`
-`|--- |--- |--- |`
-`|# Sheep | 50 | 60 | 80|`
-`|# Cows | 200 | 38 | 75|`
-`|# Pigs| 150 | 70 | 35|`
+```
+| | Woodchurch | Moat | Jenkey |
+|--- |--- |--- |
+|# Sheep | 50 | 60 | 80|
+|# Cows | 200 | 38 | 75|
+|# Pigs| 150 | 70 | 35|
+```
 
 
 > [!NOTE]

--- a/app/formatting-content/videos/index.md
+++ b/app/formatting-content/videos/index.md
@@ -46,7 +46,9 @@ You can either:
 
 Replace the text in the brackets in this template:
 
-`[Title of video](URL of video - not the embed code or the 'Share this video' URL)`
+```
+[Title of video](URL of video - not the embed code or the 'Share this video' URL)
+```
 
 Leave a line space above and below this code. If you do not leave line spaces, the content on either side of the code will be hidden behind the embedded video.
 
@@ -58,11 +60,15 @@ If a user has not accepted the 'communications and marketing' cookie, they will 
 
 If it's a YouTube video, use the following template and only replace the text in the square and round brackets:
 
-`[Link text](URL of video){:data-youtube-player="off"}`
+```
+[Link text](URL of video){:data-youtube-player="off"}
+```
 
 If it's not a YouTube video, replace the text in this template instead:
 
-`[Link text](URL of video)`
+```
+[Link text](URL of video)
+```
 
 ## Make videos accessible
 

--- a/app/writing-to-gov-uk-standards/plan-manage-content/follow-url-standards.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/follow-url-standards.md
@@ -31,9 +31,9 @@ That means they should:
 
 - be in lower case
 - use words and not acronyms, unless the acronym is very well known or it’s an acronym of an organisation with a long name
-- avoid using superfluous words like articles (a, an, the) – for example, /benefit-guide instead of /a-guide-to-benefits
-- use the verb stem when possible – for example, /apply insteading of /applying
-- use dashes to separate words within the URL – for example, /set-up-business
+- avoid using superfluous words like articles (a, an, the) – for example, `/benefit-guide` instead of `/a-guide-to-benefits`
+- use the verb stem when possible – for example, `/apply` insteading of `/applying`
+- use dashes to separate words within the URL – for example, `/set-up-business`
 
 You can choose to create URLs without dashes if you’re making a:
 
@@ -46,13 +46,13 @@ URLs should:
 
 - align with the title of the page
 - be based on user need rather than the current name of a policy, scheme or service, which might change – for example, [www.gov.uk/advertise-job](https://www.gov.uk/advertise-job) is for employers who want to use the ‘Find a job’ service
-- include the year when using a short URL for one-off promotion of an annual event – for example, /budget-2020 instead of /budget
+- include the year when using a short URL for one-off promotion of an annual event – for example, `/budget-2020` instead of `/budget`
 
 ## Avoid trailing slashes in URLs
 
 Trailing slashes should not be used when sharing or printing URLs as it's bad for search engine optimisation (SEO).
 
-For example, use www.gov.uk/your-url-here rather than www.gov.uk/your-url-here/
+For example, use `www.gov.uk/your-url-here` rather than `www.gov.uk/your-url-here/`.
 
 ## URLs must direct to government sites
 
@@ -62,16 +62,16 @@ You must not use a GOV.UK short URL to redirect a user to a non-government site.
 
 You may need to include the organisation’s name or acronym in short URLs.
 
-You should usually use the organisation’s full name, like www.gov.uk/home-office for the Home Office.
+You should usually use the organisation’s full name, like `www.gov.uk/home-office` for the Home Office.
 
 You should only use an organisation’s acronym if either:
 
-- it is very well known, like www.gov.uk/dwp for the Department for Work and Pensions (DWP)
-- the organisation has a long name, like www.gov.uk/ofdia for the Office for Digital Identities and Attributes (OfDIA)
+- it is very well known, like `www.gov.uk/dwp` for the Department for Work and Pensions (DWP)
+- the organisation has a long name, like `www.gov.uk/ofdia` for the Office for Digital Identities and Attributes (OfDIA)
 
 ### Short URLs for guidance and policy content
 
-Short URLs which redirect to Whitehall content should include the organisation name or acronym within the URL. For example, www.gov.uk/home-office/url or www.gov.uk/dwp/url.
+Short URLs which redirect to Whitehall content should include the organisation name or acronym within the URL. For example, `www.gov.uk/home-office/url` or `www.gov.uk/dwp/url`.
 
 You can ask for a short URL without an organisation name or acronym if the content:
 
@@ -80,6 +80,6 @@ You can ask for a short URL without an organisation name or acronym if the conte
 
 ### Short URLs for organisation and group pages
 
-Each government organisation on GOV.UK can have a single short URL for use when promoting its organisation page. For example, www.gov.uk/home-office or www.gov.uk/dwp.
+Each government organisation on GOV.UK can have a single short URL for use when promoting its organisation page. For example, `www.gov.uk/home-office` or `www.gov.uk/dwp`.
 
-You can also get short URLs for group pages. These should include the name of the parent organisation. For example, a group that is part of the Environment Agency (EA) takes the short URL: www.gov.uk/ea/clear-info.
+You can also get short URLs for group pages. These should include the name of the parent organisation. For example, a group that is part of the Environment Agency (EA) takes the short URL: `www.gov.uk/ea/clear-info`.


### PR DESCRIPTION
Updated the formatting for code examples on a few pages, just to standardise our approach so that:

- code lines are used for examples included in a sentence
- code blocks are used for examples split into separate lines

I tried to fix the email link example on the 'Links' page to make it a code block, but it showed up as a blank box. I assume it must be a problem with using '<>' within code blocks. I could investigate more, but this is such a minor issue that I don't think it's worth our time.

There's one example in 'Follow URL standards' that's a live URL so I have not changed that. I think it's worth letting users click through so they can understand the example better.

These are basically aesthetic changes so no update needed to the 'What's new' page.