### PR TITLE
Fix small style errors

### DIFF
--- a/app/accounts-support/make-content-requests/ask-new-organisation.md
+++ b/app/accounts-support/make-content-requests/ask-new-organisation.md
@@ -31,7 +31,7 @@ If you’re requesting a new organisation page, include in your request:
 * any other sponsoring organisations
 * an email address for users to request accessible formats of published attachments
 * if the organisation is [exempt from GOV.UK](/accounts-support/make-content-requests/ask-exemption/), the URL of the organisation’s website
-* the organisation status - GDS normally sets new pages as ‘Coming soon’ so you can add content to the page before you change the status to ‘Live’
+* the organisation status - GDS normally sets new pages as ‘Coming soon’ so you can add content to the page before you change the status to ‘Currently live’
 * the name and email address of the GOV.UK lead who’ll be responsible for the organisation and its content on GOV.UK
 * the type of organisation
 

--- a/app/publish-update-retire-content/organisations-people/groups.md
+++ b/app/publish-update-retire-content/organisations-people/groups.md
@@ -27,7 +27,7 @@ For example, the user need for a group page on a policy advisory group is for tr
 
 Group pages should not be used as a way of setting out:
 
-* the internal structure of an organisation (ie representing every team)
+* the internal structure of an organisation (such as by having a group page for every team)
 * activities performed by a group (for example, documents published) without a call to action
 
 Most groups will not need a group page, because people should not need to understand the structure of government in order to interact with it. Usually a reference to the group elsewhere on GOV.UK will be enough, such as in a [document collection](/publish-update-retire-content/standard-content-types/document-collections/).

--- a/app/publish-update-retire-content/promotional-social/campaigns.md
+++ b/app/publish-update-retire-content/promotional-social/campaigns.md
@@ -56,7 +56,7 @@ Does the campaign include steps for objectives, audience insight, strategy, impl
 
 Would it be better to link to existing GOV.UK content?
 
-Does it duplicate information already on GOV.UK? The campaign must not duplicate other content or services on GOV.UK. Read more about [what does not go on GOV.UK](/writing-to-gov-uk-standards/plan-manage-content/plan-new-govuk-content/).
+Does it duplicate information already on GOV.UK? The campaign must not duplicate other content or services on GOV.UK.
 
 Is it within the [GOV.UK proposition](https://www.gov.uk/government/publications/govuk-proposition/govuk-proposition)? You must follow the guidance in the proposition when you publish content. 
 

--- a/app/writing-to-gov-uk-standards/plan-manage-content/plan-new-govuk-content.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/plan-new-govuk-content.md
@@ -51,7 +51,7 @@ This can be published by your own content team. You’ll need to [choose an appr
 
 Specialist guidance should not:
 
-* promote government initiatives or policies - use the [campaigns platform] or other channels to support marketing or promotional activity, or use a [news story] or [press release] for announcements
+* promote government initiatives or policies - use the [campaigns platform](/publish-update-retire-content/promotional-social/campaigns/) or other channels to support marketing or promotional activity, or use a [news article](/publish-update-retire-content/standard-content-types/news-articles/) for announcements
 * explain the policy behind the guidance
 * duplicate mainstream content
 


### PR DESCRIPTION
Made four small updates to fix issues:

1. 'Campaigns' -> Removed an unhelpful link - this link originally went to a section of the proposition in the old guidance but we changed it in the move. We had feedback asking we change this link back, but I realised the following sentence was about the proposition so this link did not feel necessary at all and it was better to remove it.

2. 'Group pages' -> Removed the use of 'ie' for style reasons.

3. 'Ask for a new organisation page' -> Noticed we say 'Live' instead of 'Currently live', which is the term used in Whitehall Publisher.

4. 'Plan new GOV.UK content' -> Updated some broken link code.

No update needed to 'What's new' page.