### PR TITLE
Fix typo on URL standards page - "insteading" to "instead"

### DIFF
--- a/app/writing-to-gov-uk-standards/plan-manage-content/follow-url-standards.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/follow-url-standards.md
@@ -32,7 +32,7 @@ That means they should:
 - be in lower case
 - use words and not acronyms, unless the acronym is very well known or it’s an acronym of an organisation with a long name
 - avoid using superfluous words like articles (a, an, the) – for example, `/benefit-guide` instead of `/a-guide-to-benefits`
-- use the verb stem when possible – for example, `/apply` insteading of `/applying`
+- use the verb stem when possible – for example, `/apply` instead of `/applying`
 - use dashes to separate words within the URL – for example, `/set-up-business`
 
 You can choose to create URLs without dashes if you’re making a:


### PR DESCRIPTION
Spotted by Jayvik on Slack: https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6/p1782740486708859

There's no change to line 85 - the GitHub editor may have adjusted whitespace or something, I'm not sure why it's showing in the diff.