### PR TITLE
Update guidance on social media links

### DIFF
--- a/app/publish-update-retire-content/organisations-people/organisations.md
+++ b/app/publish-update-retire-content/organisations-people/organisations.md
@@ -206,7 +206,14 @@ Contact details are shown in the order you add them. You can reorder them using 
 
 These will show under the 'Follow us' heading under the 'What we do' section of the organisation page. They appear in the order you add them. 
 
-Avoid putting something very short in the ‘Title’ field, which appears as link text. For example, put ‘DWP on X’ rather than just ‘X’. Very short links can create problems for users with limited dexterity.
+For the ‘Title’ field, avoid:
+
+- leaving it blank (the name of the service will be used as a default)
+- using generic or very short titles (like ‘X’)
+
+The ‘Title’ field is used as link text, and generic or short link text can create accessibility issues.
+
+A good example of a title is ‘DWP on X’.
 
 ## 'Our ministers' and 'Our management'
 

--- a/app/publish-update-retire-content/promotional-social/topical-events.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events.md
@@ -103,6 +103,8 @@ You can add and remove social media accounts in the ‘Social media accounts’ 
 
 To add an account, select the ‘Add a social media account’ button and then choose the channel type and add the URL.
 
+Avoid putting something generic or very short in the ‘Title’ field, which appears as link text. For example, put ‘DWP on X’ rather than just ‘X’. Generic or short link text can create accessibility issues.
+
 ## Add or edit images
 
 You can add:


### PR DESCRIPTION
Updated the guidance on adding social media links to organisation pages, to reflect that default titles and generic titles can also cause accessibility issues.

Added similar guidance to the topical event page guidance, as social media links can also be added there.

This is minor enough that I don't think a 'What's new' update is needed.