### PR TITLE
Update history mode guidance

### DIFF
--- a/_includes/reusable-content/political-heading.md
+++ b/_includes/reusable-content/political-heading.md
@@ -1,1 +1,1 @@
-Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only be important if your organisation is asked to take part in an audit of content before a general election.
+Do not change anything under the 'Political' heading. This is related to [history mode](/writing-to-gov-uk-standards/plan-manage-content/retire-content) and it will only be important if your organisation is asked to take part in an audit of content before a potential change in government.

--- a/app/publish-update-retire-content/standard-content-types/calls-for-evidence.md
+++ b/app/publish-update-retire-content/standard-content-types/calls-for-evidence.md
@@ -85,7 +85,6 @@ If you're uploading a HTML attachment, read the [formatting guidance](/formattin
 5. Make any changes to the title, summary and body as needed. {% include 'reusable-content/style-formatting.md' %}
 
 6. {% include 'reusable-content/political-heading.md' %}
-
 7. Change the options under 'Excluded nations (required)' if needed.
 8. {% include 'reusable-content/limit-access.md' %}
 

--- a/app/publish-update-retire-content/standard-content-types/case-studies.md
+++ b/app/publish-update-retire-content/standard-content-types/case-studies.md
@@ -64,7 +64,6 @@ After saving the page, you can add images and attachments.
 5. Make any changes to the title, summary or body as needed. {% include 'reusable-content/style-formatting.md' %}
 
 6. {% include 'reusable-content/political-heading.md' %}
-
 7. {% include 'reusable-content/limit-access.md' %}
 
 8. {% include 'reusable-content/change-notes.md' %}

--- a/app/publish-update-retire-content/standard-content-types/consultations.md
+++ b/app/publish-update-retire-content/standard-content-types/consultations.md
@@ -93,7 +93,6 @@ If you're uploading a HTML attachment, read the [formatting guidance](/formattin
 5. Make any changes to the title, summary and body as needed. {% include 'reusable-content/style-formatting.md' %}
 
 6. {% include 'reusable-content/political-heading.md' %}
-
 7. Change the options under 'Excluded nations (required)' if needed.
 8. {% include 'reusable-content/limit-access.md' %}
 

--- a/app/publish-update-retire-content/standard-content-types/detailed-guides.md
+++ b/app/publish-update-retire-content/standard-content-types/detailed-guides.md
@@ -51,7 +51,6 @@ After saving the page, you can add attachments and images.
 5. Make any changes to the title, summary or body as needed. {% include 'reusable-content/style-formatting.md' %}
 
 6. {% include 'reusable-content/political-heading.md' %}
-
 7. Change the options under 'Excluded nations (required)' if needed.
 8. {% include 'reusable-content/limit-access.md' %}
 

--- a/app/publish-update-retire-content/standard-content-types/document-collections.md
+++ b/app/publish-update-retire-content/standard-content-types/document-collections.md
@@ -65,7 +65,6 @@ After saving the page, you can start adding the collection itself.
 5. Make any changes to the title, summary and body as needed. {% include 'reusable-content/style-formatting.md' %}
 
 6. {% include 'reusable-content/political-heading.md' %}
-
 7. {% include 'reusable-content/limit-access.md' %}
 
 8. {% include 'reusable-content/change-notes.md' %}

--- a/app/publish-update-retire-content/standard-content-types/news-articles.md
+++ b/app/publish-update-retire-content/standard-content-types/news-articles.md
@@ -100,7 +100,6 @@ If you're correcting an error:
 5. Make any changes to the title, summary or body as needed. {% include 'reusable-content/style-formatting.md' %}
 
 6. {% include 'reusable-content/political-heading.md' %}
-
 7. {% include 'reusable-content/limit-access.md' %}
 
 8. {% include 'reusable-content/change-notes.md' %}

--- a/app/publish-update-retire-content/standard-content-types/publications.md
+++ b/app/publish-update-retire-content/standard-content-types/publications.md
@@ -196,7 +196,6 @@ After saving the page, you can add attachments and images.
 3. Search for the publication you want to edit, and select the 'View' link next to it. This will take you to the edition summary page. If you only want to update the topic tags and nothing else, select 'Change tags' under 'Topic taxonomy tags'. Otherwise, keep following these steps.
 4. Select the 'Create new edition' button. If a new edition has already been created, select the 'Go to draft' link. You can then select 'Edit draft' or, if you do not want to use this draft, select 'Delete draft' and then select 'Create new edition'.
 5. {% include 'reusable-content/political-heading.md' %}
-
 6. Make any changes to the title, summary or body as needed. Read the [tone of voice guidance](/writing-to-gov-uk-standards/tone-of-voice/) and [formatting guidance](/formatting-content/) for help.
 7. Change the options under 'Excluded nations (required)' if needed.
 8. {% include 'reusable-content/limit-access.md' %}

--- a/app/publish-update-retire-content/standard-content-types/speeches.md
+++ b/app/publish-update-retire-content/standard-content-types/speeches.md
@@ -91,7 +91,6 @@ If you're correcting an error:
 5. Make any changes to the title, summary, body and speech details as needed. {% include 'reusable-content/style-formatting.md' %}
 
 6. {% include 'reusable-content/political-heading.md' %}
-
 7. {% include 'reusable-content/limit-access.md' %}
 
 8. {% include 'reusable-content/change-notes.md' %}

--- a/app/publish-update-retire-content/standard-content-types/statistical-data-sets.md
+++ b/app/publish-update-retire-content/standard-content-types/statistical-data-sets.md
@@ -52,7 +52,6 @@ After saving the page, you can add the data set as an attachment.
 5. Make any changes to the title, summary or body as needed. {% include 'reusable-content/style-formatting.md' %}
 
 6. {% include 'reusable-content/political-heading.md' %}
-
 7. {% include 'reusable-content/limit-access.md' %}
 
 8. {% include 'reusable-content/change-notes.md' %}

--- a/app/publish-update-retire-content/standard-content-types/statistics.md
+++ b/app/publish-update-retire-content/standard-content-types/statistics.md
@@ -118,7 +118,6 @@ When the statistics publication is published, the announcement will disappear fr
 3. Select the 'Create new edition' button.
 4. Make your changes.
 5. {% include 'reusable-content/political-heading.md' %}
-
 6. {% include 'reusable-content/change-notes.md' %}
 7. Select the 'Save' button at the bottom of the page.
 8. Select 'Submit for 2nd eyes'. This will allow another editor to [review your document](/publish-update-retire-content/standard-content-types/review-standard/) and then they can publish or schedule it.


### PR DESCRIPTION
Updated the reusable content snippet to reflect that history mode audits may happen when governments change for reasons other than a general election (like a new Prime Minister).