### PR TITLE
Update Keir Starmer to Andy Burnham in Prime Minister section

### DIFF
--- a/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
+++ b/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
@@ -2088,7 +2088,7 @@ Title case because it's the name of an organisation.
 
 ### Prime Minister
 
-Use Prime Minister Keir Starmer and the Prime Minister.
+Use Prime Minister Andy Burnham and the Prime Minister.
 
 ### priority school building programme
 


### PR DESCRIPTION
Burnham uses 'Andy' rather than 'Andrew', per his parliamentary profile: https://members.parliament.uk/member/1427/contact and biography on GOV.UK: https://www.gov.uk/government/people/andy-burnham