### PR TITLE
Improve emergency support findability

### DIFF
--- a/app/accounts-support/get-content-advice/get-help-advice.md
+++ b/app/accounts-support/get-content-advice/get-help-advice.md
@@ -5,9 +5,12 @@ order: 1
 eleventyNavigation:
   parent: Get content advice
 title: Get help and advice
-description: Learn how to get content advice from the GDS content team and from the cross-government content community on Slack and Basecamp.
+description: Ask for support with content design and publishing from GDS and from the cross-government content community on Slack and Basecamp.
 lastUpdated:
 ---
+
+[[toc]]
+
 ## Support from the Government Digital Service (GDS)
 
 You can ask for content advice from the GDS content team. This could be about, for example:
@@ -29,7 +32,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
 
 ### Emergency support for publishing requests 
 
-If you have an emergency relating to publishing to GOV.UK use the [GOV.UK emergency contact details](https://support.publishing.service.gov.uk/emergency-contact-details). You’ll need a Signon account to access those details.
+If you have an emergency relating to publishing to GOV.UK, use the [GOV.UK emergency contact details](https://support.publishing.service.gov.uk/emergency-contact-details). You’ll need a Signon account to access those details.
 
 You should only use these emergency contact details when:
 

--- a/app/accounts-support/make-content-requests/ask-updates-content.md
+++ b/app/accounts-support/make-content-requests/ask-updates-content.md
@@ -15,7 +15,7 @@ lastUpdated:
 
 There are different ways to ask for a change depending on whether you want to work on ‘Whitehall’ or ‘mainstream’ content.
 
-Whitehall content is managed by your organisation’s GOV.UK publishing team. You need to contact them to create or update Whitehall content. They can get [content advice from GDS](/accounts-support/get-content-advice/get-help-advice/) if they need help with that.
+Whitehall content is managed by you and your organisation’s GOV.UK publishing team. If you need help making a change to Whitehall content, you can [contact GDS for help with publishing content](/accounts-support/get-content-advice/get-help-advice/).
 
 Mainstream content is managed by GDS. You need to ask them to create or update mainstream content. We explain how to do that in the following guidance.
 


### PR DESCRIPTION
Added a TOC and new meta description to 'Get help and advice' so that it's easier to find the details on requesting emergency support from GDS.

Made the link text clearer in 'Ask for updates to GOV.UK content' so it's easier to find 'Get help and advice' from that page.

Minor stylistic changes, so no 'What's new' update needed.