### PR TITLE
Update 'Feature content' guidance for topical event pages

### DIFF
--- a/app/publish-update-retire-content/promotional-social/topical-events-old.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events-old.md
@@ -104,40 +104,53 @@ Use this page to give more detailed information on what the government is doing 
 6. Complete the 'Body' section.
 7. Select 'Save'. The draft will be published immediately.
 
-## Tag a piece of content to the topical event page
+## Feature content 
 
-You can tag content by adding an association to the topical event. You can do it for these content types:
+You can feature up to 6 pieces of content. Any items you feature must include an image. Read the guidance on [formatting images](/formatting-content/images/) for help with picking an image. 
 
-- [call for evidence](/publish-update-retire-content/standard-content-types/calls-for-evidence/)
-- [consultation](/publish-update-retire-content/standard-content-types/consultations/)
-- [detailed guide](/publish-update-retire-content/standard-content-types/detailed-guides/)
-- [document collection](/publish-update-retire-content/standard-content-types/document-collections/)
-- [news article](/publish-update-retire-content/standard-content-types/news-articles)
-- [publication](/publish-update-retire-content/standard-content-types/publications/)
-- [speech](/publish-update-retire-content/standard-content-types/speeches/)
+### Feature content published through Whitehall Publisher 
 
-Content tagged to the topical event will automatically appear in the 'Latest' feed.
+You can feature these content types: 
 
-## Feature tagged content
+- [calls for evidence](/publish-update-retire-content/standard-content-types/calls-for-evidence/) 
+- [consultations](/publish-update-retire-content/standard-content-types/consultations/) 
+- [detailed guides](/publish-update-retire-content/standard-content-types/detailed-guides/) 
+- [document collections](/publish-update-retire-content/standard-content-types/document-collections/) 
+- [news articles](/publish-update-retire-content/standard-content-types/news-articles) 
+- [publications](/publish-update-retire-content/standard-content-types/publications/) 
+- [speeches](/publish-update-retire-content/standard-content-types/speeches/) 
+ 
+You need to tag the content to the topical event before it can be featured. Do this by publishing a draft with the topical event selected under the ‘Topical events’ heading. 
 
-You can feature up to 6 pieces of content. Any items you feature must include an image. Read the guidance on [formatting images](/formatting-content/images/) for help with picking an image.
+> [!NOTE] 
+> All content tagged to the topical event will automatically appear in the 'Latest' feed, even if it's not featured.
 
-If the content is published through Whitehall Publisher:
+Once the content has been tagged to the topical event and published: 
 
-1. Select the 'Featured' tab.
-2. Select the 'GOV.UK content' tab.
-3. Search for the document you want to feature using the filters on the left hand side. Only content tagged to the topical event will show in the list.
-4. Select the 'Feature' link next to the document you would like to feature.
-5. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text.
+1. Select the 'Featured' tab. 
+2. Select the 'GOV.UK content' tab. 
+3. Search for the content you want to feature using the filters.  
+4. Select the 'Feature' link next to the content you would like to feature. 
+5. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text. 
 
-If the content is not published through Whitehall Publisher:
+### Feature content not published through Whitehall Publisher 
 
-1. Select the 'Featured' tab.
-2. Select the 'External websites' tab.
-3. Select 'Add an external link'.
-4. Complete the title, summary, type and URL fields and select 'Save'.
-5. Select the 'Feature' link next to the external page you would like to feature.
-6. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text.
+You can feature content with a URL ending in: 
+
+- gov.uk
+- nhs.uk 
+- royal.uk 
+- victimandwitnessinformation.org.uk 
+- energygovuk.citizenspace.com 
+
+Once you have a link: 
+
+1. Select the 'Featured' tab.  
+2. Select the 'External websites' tab.  
+3. Select 'Add an external link'.  
+4. Complete the title, summary, type and URL fields and select 'Save'.  
+5. Select the 'Feature' link next to the external page you would like to feature.  
+6. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text. 
 
 ### Change the order of featured content
 

--- a/app/publish-update-retire-content/promotional-social/topical-events-old.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events-old.md
@@ -135,7 +135,7 @@ Once the content has been tagged to the topical event and published:
 
 ### Feature content not published through Whitehall Publisher 
 
-You can feature content with a URL ending in: 
+You can only feature content with a URL ending in: 
 
 - gov.uk
 - nhs.uk 

--- a/app/publish-update-retire-content/promotional-social/topical-events.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events.md
@@ -125,40 +125,53 @@ If the image requires cropping, it will say this when you go back to the ‘Imag
 
 Select ‘Edit’ to crop the image or to edit the caption on header images.
 
-## Tag a piece of content to the topical event page
+## Feature content 
 
-You can tag content by adding an association to the topical event. You can do it for these content types:
+You can feature up to 6 pieces of content. Any items you feature must include an image. Read the guidance on [formatting images](/formatting-content/images/) for help with picking an image. 
 
-- [call for evidence](/publish-update-retire-content/standard-content-types/calls-for-evidence/)
-- [consultation](/publish-update-retire-content/standard-content-types/consultations/)
-- [detailed guide](/publish-update-retire-content/standard-content-types/detailed-guides/)
-- [document collection](/publish-update-retire-content/standard-content-types/document-collections/)
-- [news article](/publish-update-retire-content/standard-content-types/news-articles)
-- [publication](/publish-update-retire-content/standard-content-types/publications/)
-- [speech](/publish-update-retire-content/standard-content-types/speeches/)
+### Feature content published through Whitehall Publisher 
 
-Content tagged to the topical event will automatically appear in the 'Latest' feed.
+You can feature these content types: 
 
-## Feature tagged content
+- [calls for evidence](/publish-update-retire-content/standard-content-types/calls-for-evidence/) 
+- [consultations](/publish-update-retire-content/standard-content-types/consultations/) 
+- [detailed guides](/publish-update-retire-content/standard-content-types/detailed-guides/) 
+- [document collections](/publish-update-retire-content/standard-content-types/document-collections/) 
+- [news articles](/publish-update-retire-content/standard-content-types/news-articles) 
+- [publications](/publish-update-retire-content/standard-content-types/publications/) 
+- [speeches](/publish-update-retire-content/standard-content-types/speeches/) 
+ 
+You need to tag the content to the topical event before it can be featured. Do this by publishing a draft with the topical event selected under the ‘Topical events (experimental)’ heading. 
 
-You can feature up to 6 pieces of content. Any items you feature must include an image. Read the guidance on [formatting images](/formatting-content/images/) for help with picking an image.
+> [!NOTE] 
+> All content tagged to the topical event will automatically appear in the 'Latest' feed, even if it's not featured.
 
-If the content is published through Whitehall Publisher:
+Once the content has been tagged to the topical event and published: 
 
-1. Select the 'Featured' tab.
-2. Select the 'GOV.UK content' tab.
-3. Search for the document you want to feature using the filters on the left hand side. Only content tagged to the topical event will show in the list.
-4. Select the 'Feature' link next to the document you would like to feature.
-5. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text.
+1. Select the 'Featured' tab. 
+2. Select the 'GOV.UK content' tab. 
+3. Search for the content you want to feature using the filters.  
+4. Select the 'Feature' link next to the content you would like to feature. 
+5. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text. 
 
-If the content is not published through Whitehall Publisher:
+### Feature content not published through Whitehall Publisher 
 
-1. Select the 'Featured' tab.
-2. Select the 'External websites' tab.
-3. Select 'Add an external link'.
-4. Complete the title, summary, type and URL fields and select 'Save'.
-5. Select the 'Feature' link next to the external page you would like to feature.
-6. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text.
+You can feature content with a URL ending in: 
+
+- gov.uk
+- nhs.uk 
+- royal.uk 
+- victimandwitnessinformation.org.uk 
+- energygovuk.citizenspace.com 
+
+Once you have a link: 
+
+1. Select the 'Featured' tab.  
+2. Select the 'External websites' tab.  
+3. Select 'Add an external link'.  
+4. Complete the title, summary, type and URL fields and select 'Save'.  
+5. Select the 'Feature' link next to the external page you would like to feature.  
+6. Select an image to be shown on your topical event page with this feature. You do not need to provide alt text. 
 
 ### Change the order of featured content
 

--- a/app/publish-update-retire-content/promotional-social/topical-events.md
+++ b/app/publish-update-retire-content/promotional-social/topical-events.md
@@ -156,7 +156,7 @@ Once the content has been tagged to the topical event and published:
 
 ### Feature content not published through Whitehall Publisher 
 
-You can feature content with a URL ending in: 
+You can only feature content with a URL ending in: 
 
 - gov.uk
 - nhs.uk 

--- a/package-lock.json
+++ b/package-lock.json
@@ -803,9 +803,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -825,9 +822,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -849,9 +843,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -871,9 +862,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -895,9 +883,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -917,9 +902,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1173,9 +1155,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1188,9 +1167,6 @@
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1205,9 +1181,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1220,9 +1193,6 @@
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1237,9 +1207,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1252,9 +1219,6 @@
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1269,9 +1233,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1284,9 +1245,6 @@
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1301,9 +1259,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1316,9 +1271,6 @@
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1333,9 +1285,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1349,9 +1298,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,9 +1310,6 @@
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Updated the wording for the two topical event pages so it's clearer that:

1) Users need to tag Whitehall content to the topical event before it can be featured.

2) Only published Whitehall content can be featured.

3) For new topical events, you tag Whitehall content under the 'Topical events (experimental)' heading. For old ones, it's the 'Topical events' heading.

4) Only certain URLs can be used when featuring non-Whitehall content.

These are just wording changes so no need for a 'What's new' update.