### PR TITLE
Update 'Ofsted judgements' style guide entry

### DIFF
--- a/app/about-the-guidance/whats-new.md
+++ b/app/about-the-guidance/whats-new.md
@@ -14,6 +14,7 @@ This page sets out all recent major updates to the GOV.UK content and publishing
 
 | Date | Section | Update |
 | --------- | ----------- | ----------- |
+| 11 August | [A to Z style guide](/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/) | Updated entry for 'Ofsted judgements' to reflect new grading system. |
 | 5 August | [Ask for limited access to drafts to be changed](/accounts-support/make-content-requests/ask-access-limit-reset/) | Added guidance on how to ask for limited access to drafts to be changed. |
 | 4 August | [Retire outdated content](/writing-to-gov-uk-standards/plan-manage-content/retire-content/) | Updated the section on history mode to make it clearer which content types can go into history mode. |
 

--- a/app/index.md
+++ b/app/index.md
@@ -7,8 +7,8 @@ description: Read the standards for digital content and find out how to use the 
 includeInBreadcrumbs: true
 eleventyExcludeFromCollections: false
 inverseMasthead: true
-whatsNewDate: 5 August 2026
-whatsNewHeadline: Added guidance on asking for limit access to drafts to be changed
+whatsNewDate: 11 August 2026
+whatsNewHeadline: Updated style guide entry for 'Ofsted judgements' to reflect new grading system
 whatsNew: Read more about [recent changes to the guidance](/about-the-guidance/whats-new/).
 gridItems:
   - title: A to Z style guide

--- a/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
+++ b/app/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide.md
@@ -1865,14 +1865,15 @@ Lower case. This term covers both company and public sector pension schemes. Onl
 
 ### Ofsted judgements
 
-Lower case and not in single quote marks: Westminster School was judged outstanding in its latest Ofsted inspection.
-
-There are 4 Ofsted grades:
-
-* outstanding (or grade 1)
-* good (or grade 2)
-* requires improvement (or grade 3)
-* inadequate (or grade 4)
+Lower case and only in single quote marks if part of a sentence. For example: 'Example School met the ‘expected standard’ for leadership and governance.'
+ 
+There are 5 Ofsted grades:
+ 
+* exceptional
+* strong standard
+* expected standard
+* needs attention
+* urgent improvement
 
 ### one-year-on
 


### PR DESCRIPTION
Updated the style guide entry for 'Ofsted judgements', as the grading system has now changed.

I checked the changes with the Ofsted content team and they were happy. They were the ones who asked we specify that single quotes should only be used when the grade is part of a sentence, and I agree that it does add to readability.

Made this a 'What's new' update. It is a minor change that will not affect many, but users like to know about style guide changes and have a record.