### PR TITLE
Added detail component for if users cannot access content advice form

### DIFF
--- a/app/about-the-guidance/whats-new.md
+++ b/app/about-the-guidance/whats-new.md
@@ -14,7 +14,7 @@ This page sets out all recent major updates to the GOV.UK content and publishing
 
 | Date | Section | Update |
 | --------- | ----------- | ----------- |
-| 19 August | [Ask for a short URL](/accounts-support/make-content-requests/ask-short-url/), [Downtime messages](/accounts-support/make-content-requests/ask-downtime-messages/) and [Specialist finders](/publish-update-retire-content/other-content-types/specialist-finders/) | Updated permissions on making requests to GDS |
+| 19 August | [Ask for a short URL](/accounts-support/make-content-requests/ask-short-url/), [Ask for downtime messages](/accounts-support/make-content-requests/ask-downtime-messages/) and [Specialist finders](/publish-update-retire-content/other-content-types/specialist-finders/) | Updated to remove the rule that only GOV.UK leads and managing editors can make requests related to these matters. Anyone with access to the relevant form can make a request. |
 | 17 August | [Blogs](/publish-update-retire-content/promotional-social/blogs/) | Added a link to the new blog request form. |
 | 11 August | [A to Z style guide](/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/) | Updated entry for 'Ofsted judgements' to reflect new grading system. |
 | 5 August | [Ask for limited access to drafts to be changed](/accounts-support/make-content-requests/ask-access-limit-reset/) | Added guidance on how to ask for limited access to drafts to be changed. |

--- a/app/about-the-guidance/whats-new.md
+++ b/app/about-the-guidance/whats-new.md
@@ -14,6 +14,7 @@ This page sets out all recent major updates to the GOV.UK content and publishing
 
 | Date | Section | Update |
 | --------- | ----------- | ----------- |
+| 19 August | [Ask for a short URL](/accounts-support/make-content-requests/ask-short-url/), [Downtime messages](/accounts-support/make-content-requests/ask-downtime-messages/) and [Specialist finders](/publish-update-retire-content/other-content-types/specialist-finders/) | Updated permissions on making requests to GDS |
 | 11 August | [A to Z style guide](/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/) | Updated entry for 'Ofsted judgements' to reflect new grading system. |
 | 5 August | [Ask for limited access to drafts to be changed](/accounts-support/make-content-requests/ask-access-limit-reset/) | Added guidance on how to ask for limited access to drafts to be changed. |
 | 4 August | [Retire outdated content](/writing-to-gov-uk-standards/plan-manage-content/retire-content/) | Updated the section on history mode to make it clearer which content types can go into history mode. |

--- a/app/accounts-support/get-content-advice/get-content-service-review.md
+++ b/app/accounts-support/get-content-advice/get-content-service-review.md
@@ -36,7 +36,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/accounts-support/get-content-advice/get-content-service-review.md
+++ b/app/accounts-support/get-content-advice/get-content-service-review.md
@@ -25,7 +25,20 @@ If GDS cannot do the review, get someone in your department to do it instead.
 
 Send in the request at least 4 weeks before the date of the service assessment.
 
-Use the [content requests form](https://support.publishing.service.gov.uk/content_change_request/new) and select ‘service review’ as the reason for the request. You need a Signon account with ‘content requesters’ permissions to access the form. Speak to your GOV.UK lead if you want access to the form.
+Use the [content requests form](https://support.publishing.service.gov.uk/content_change_request/new) and select ‘service review’ as the reason for the request. 
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the content requests form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content requests form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 Include the following information:
 

--- a/app/accounts-support/get-content-advice/get-help-advice.md
+++ b/app/accounts-support/get-content-advice/get-help-advice.md
@@ -28,7 +28,19 @@ It may be a quick question about content you’re working on or a request for a 
   
 [Ask for advice from GDS](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
 
 ### Emergency support for publishing requests 
 

--- a/app/accounts-support/get-content-advice/get-help-advice.md
+++ b/app/accounts-support/get-content-advice/get-help-advice.md
@@ -37,7 +37,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/accounts-support/make-content-requests/ask-access-limit-reset.md
+++ b/app/accounts-support/make-content-requests/ask-access-limit-reset.md
@@ -29,9 +29,19 @@ If you know them, include in your request:
 * the title of the draft 
 * the name of the person who created the draft
 
-Use the [content advice form]( https://signon.publishing.service.gov.uk/users/sign_in) to make your request.   
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the form. Speak to your GOV.UK lead or managing editor if you want access.   
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
 
 
 *[GDS]: Government Digital Service

--- a/app/accounts-support/make-content-requests/ask-access-limit-reset.md
+++ b/app/accounts-support/make-content-requests/ask-access-limit-reset.md
@@ -29,7 +29,7 @@ If you know them, include in your request:
 * the title of the draft 
 * the name of the person who created the draft
 
-Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -38,7 +38,7 @@ Use the [content advice form](https://support.publishing.service.gov.uk/content_
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/accounts-support/make-content-requests/ask-changes-topics.md
+++ b/app/accounts-support/make-content-requests/ask-changes-topics.md
@@ -16,7 +16,7 @@ You can also suggest changes to an existing topic.
 
 You need a Signon account to make these requests. Speak to your GOV.UK lead or one of your organisation admins if you want an account. 
 
-Your GOV.UK lead will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
 
 
 ## Add a new topic

--- a/app/accounts-support/make-content-requests/ask-changes-topics.md
+++ b/app/accounts-support/make-content-requests/ask-changes-topics.md
@@ -16,6 +16,9 @@ You can also suggest changes to an existing topic.
 
 You need a Signon account to make these requests. Speak to your GOV.UK lead if you want access.
 
+Your GOV.UK lead will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+
+
 ## Add a new topic
 
 Use the [new topic request form](https://support.publishing.service.gov.uk/taxonomy_new_topic_request/new) to make your request.

--- a/app/accounts-support/make-content-requests/ask-changes-topics.md
+++ b/app/accounts-support/make-content-requests/ask-changes-topics.md
@@ -14,7 +14,7 @@ If there’s no topic that describes what your content is about, you can ask the
 
 You can also suggest changes to an existing topic.
 
-You need a Signon account to make these requests. Speak to your GOV.UK lead if you want access.
+You need a Signon account to make these requests. Speak to your GOV.UK lead or one of your organisation admins if you want an account. 
 
 Your GOV.UK lead will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
 

--- a/app/accounts-support/make-content-requests/ask-downtime-messages.md
+++ b/app/accounts-support/make-content-requests/ask-downtime-messages.md
@@ -52,6 +52,19 @@ Ask for the downtime messages 5 working days in advance of the downtime. Give GD
 
 Use the [content requests form](https://support.publishing.service.gov.uk/content_change_request/new) to make the request.
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content requests form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
 In your request, include:
 
 - the URLs of the pages which need the message and the position of the link to your service on the page

--- a/app/accounts-support/make-content-requests/ask-downtime-messages.md
+++ b/app/accounts-support/make-content-requests/ask-downtime-messages.md
@@ -46,8 +46,6 @@ GDS generally does not add downtime messages to mainstream content if:
 
 ## Asking GDS for downtime messages
 
-You need to be the GOV.UK lead for your organisation to make the request.
-
 Ask for the downtime messages 5 working days in advance of the downtime. Give GDS as much time as possible if more than one service is affected. They’ll always try to give users at least a day’s notice of downtime.
 
 Use the [content requests form](https://support.publishing.service.gov.uk/content_change_request/new) to make the request.

--- a/app/accounts-support/make-content-requests/ask-featured-slot-homepage.md
+++ b/app/accounts-support/make-content-requests/ask-featured-slot-homepage.md
@@ -29,9 +29,18 @@ The 'Popular on GOV.UK' section is based on user data and is regularly updated b
 
 Ask for a featured slot using the [content requests form](https://support.publishing.service.gov.uk/content_change_request/new). 
 
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
->[!NOTE]
->You need a Signon account with ‘content requesters’ permissions to access the form. Speak to the lead of your GOV.UK publishing team if you want access to the form.
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content requests form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 Send the request at least 4 working days before you want the featured slot to go live. 
 

--- a/app/accounts-support/make-content-requests/ask-featured-slot-homepage.md
+++ b/app/accounts-support/make-content-requests/ask-featured-slot-homepage.md
@@ -38,7 +38,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/accounts-support/make-content-requests/ask-feedback-page.md
+++ b/app/accounts-support/make-content-requests/ask-feedback-page.md
@@ -32,7 +32,18 @@ The feedback page will be hidden from search engines, so it can be published bef
 
 Use the [content requests form](https://support.publishing.service.gov.uk/content_change_request/new) to submit your request.
 
-You need a Signon account with ‘content requesters’ permissions to access the form. Speak to your GOV.UK lead if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content requests form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content requests form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 ## Access the collected feedback
 

--- a/app/accounts-support/make-content-requests/ask-feedback-page.md
+++ b/app/accounts-support/make-content-requests/ask-feedback-page.md
@@ -32,7 +32,7 @@ The feedback page will be hidden from search engines, so it can be published bef
 
 Use the [content requests form](https://support.publishing.service.gov.uk/content_change_request/new) to submit your request.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content requests form. 
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -41,7 +41,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/accounts-support/make-content-requests/ask-history-mode.md
+++ b/app/accounts-support/make-content-requests/ask-history-mode.md
@@ -22,7 +22,7 @@ If it was published under an earlier government or you cannot find a managing ed
 > [!NOTE]
 > After 11 September 2026, no one will be able to update or unpublish content in history mode from the Starmer government without raising a request with GDS.
 
-Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -31,7 +31,7 @@ Use the [content advice form](https://support.publishing.service.gov.uk/content_
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/accounts-support/make-content-requests/ask-history-mode.md
+++ b/app/accounts-support/make-content-requests/ask-history-mode.md
@@ -22,9 +22,18 @@ If it was published under an earlier government or you cannot find a managing ed
 > [!NOTE]
 > After 11 September 2026, no one will be able to update or unpublish content in history mode from the Starmer government without raising a request with GDS.
 
-Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request.
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the form. Speak to your GOV.UK lead or managing editor if you want access.
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 > [!NOTE]
 > Read more about [when history mode will be applied to content](/writing-to-gov-uk-standards/plan-manage-content/retire-content/#when-history-mode-gets-applied).

--- a/app/accounts-support/make-content-requests/ask-new-organisation.md
+++ b/app/accounts-support/make-content-requests/ask-new-organisation.md
@@ -75,7 +75,7 @@ To have its own organisation page, the sub-organisation should have:
 
 ## How to make your request
 
-Use the [content advice support form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request.
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request.
 
 You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 

--- a/app/accounts-support/make-content-requests/ask-new-organisation.md
+++ b/app/accounts-support/make-content-requests/ask-new-organisation.md
@@ -77,7 +77,18 @@ To have its own organisation page, the sub-organisation should have:
 
 Use the [content advice support form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice support form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 ## What happens after you make a request
 

--- a/app/accounts-support/make-content-requests/ask-short-url.md
+++ b/app/accounts-support/make-content-requests/ask-short-url.md
@@ -66,13 +66,20 @@ Each government department, agency or arm’s length body on GOV.UK can have a s
 
 ## Asking for a short URL
 
-You can ask for a short URL if you’re the GOV.UK lead or a managing editor in your organisation.
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 Submit your request at least 2 weeks before you need it. The Government Digital Service (GDS) might not be able to meet your deadline if they do not get the full 2 weeks' notice.
-
-Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new).
-
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. Speak to your GOV.UK lead or managing editor if you want access to the form.
 
 Include in your request:
 

--- a/app/accounts-support/make-content-requests/ask-short-url.md
+++ b/app/accounts-support/make-content-requests/ask-short-url.md
@@ -66,7 +66,9 @@ Each government department, agency or arm’s length body on GOV.UK can have a s
 
 ## Asking for a short URL
 
-Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+Submit your request at least 2 weeks before you need it. The Government Digital Service (GDS) might not be able to meet your deadline if they do not get the full 2 weeks' notice.
+
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -79,7 +81,7 @@ Use the [content advice form](https://support.publishing.service.gov.uk/content_
   </div>
 </details>
 
-Submit your request at least 2 weeks before you need it. The Government Digital Service (GDS) might not be able to meet your deadline if they do not get the full 2 weeks' notice.
+
 
 Include in your request:
 

--- a/app/accounts-support/make-content-requests/ask-update-remove-related-links.md
+++ b/app/accounts-support/make-content-requests/ask-update-remove-related-links.md
@@ -23,7 +23,7 @@ If you're asking for them to be updated, you must include:
 * why the user need cannot be met by adding the link to the main body of the content
 * any supporting evidence or insights 
 
-Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -32,7 +32,7 @@ Use the [content advice form](https://support.publishing.service.gov.uk/content_
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/accounts-support/make-content-requests/ask-update-remove-related-links.md
+++ b/app/accounts-support/make-content-requests/ask-update-remove-related-links.md
@@ -23,9 +23,18 @@ If you're asking for them to be updated, you must include:
 * why the user need cannot be met by adding the link to the main body of the content
 * any supporting evidence or insights 
 
-Use the [content advice support form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request. 
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice support form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 Requests to update related links are reviewed on a case by case basis.
 

--- a/app/accounts-support/make-content-requests/ask-updates-content.md
+++ b/app/accounts-support/make-content-requests/ask-updates-content.md
@@ -55,7 +55,18 @@ It's fine to suggest wording if it helps to explain what's changed. However, the
 
 Use the [content requests form](https://support.publishing.service.gov.uk/content_change_request/new). 
 
-You need a Signon account with ‘content requesters’ permissions to access the form. Speak to your GOV.UK lead if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content requests form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 ### If you need emergency support
 

--- a/app/accounts-support/manage-accounts-training/manage-accounts-organisation.md
+++ b/app/accounts-support/manage-accounts-training/manage-accounts-organisation.md
@@ -27,6 +27,8 @@ You cannot give anyone the ‘managing editor’ permission for Whitehall Publis
 ## How to get organisation admin permissions
 Ask your GOV.UK lead to make a request using the [accounts request form](https://support.publishing.service.gov.uk/change_existing_user_request/new).
 
+Your GOV.UK lead will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+
 Super organisation admins can do all the same things as other organisation admins, but for all sub-organisations that your organisation looks after.
 
 You can get super organisation admin permissions if you manage the accounts of people in your department’s agencies who have access to GOV.UK tools. 

--- a/app/accounts-support/manage-accounts-training/manage-accounts-organisation.md
+++ b/app/accounts-support/manage-accounts-training/manage-accounts-organisation.md
@@ -24,12 +24,12 @@ If you have organisation admin permissions, you can do the following for people 
 
 You cannot give anyone the ‘managing editor’ permission for Whitehall Publisher. You must submit a request using the [accounts request form](https://support.publishing.service.gov.uk/change_existing_user_request/new) instead.
 
-## How to get organisation admin permissions
+Super organisation admins can do all the same things as other organisation admins, but for all sub-organisations that your organisation looks after.
+
+## How to get organisation admin or super organisation admin permissions
 Ask your GOV.UK lead to make a request using the [accounts request form](https://support.publishing.service.gov.uk/change_existing_user_request/new).
 
 Your GOV.UK lead will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
-
-Super organisation admins can do all the same things as other organisation admins, but for all sub-organisations that your organisation looks after.
 
 You can get super organisation admin permissions if you manage the accounts of people in your department’s agencies who have access to GOV.UK tools. 
 

--- a/app/accounts-support/manage-accounts-training/manage-accounts.md
+++ b/app/accounts-support/manage-accounts-training/manage-accounts.md
@@ -17,6 +17,8 @@ Your GOV.UK lead or an organisation admin can [request training and accounts](/a
 
 They can also request changes to your permissions - for example, if you need to be an editor in Whitehall Publisher.
 
+Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+
 ## Sign in to Signon
 
 If you have a Signon account, you can sign in to the 2 publishing environments.

--- a/app/index.md
+++ b/app/index.md
@@ -7,8 +7,8 @@ description: Read the standards for digital content and find out how to use the 
 includeInBreadcrumbs: true
 eleventyExcludeFromCollections: false
 inverseMasthead: true
-whatsNewDate: 11 August 2026
-whatsNewHeadline: Updated style guide entry for 'Ofsted judgements' to reflect new grading system
+whatsNewDate: 19 August 2026
+whatsNewHeadline: Updated permissions for making some requests to GDS
 whatsNew: Read more about [recent changes to the guidance](/about-the-guidance/whats-new/).
 gridItems:
   - title: A to Z style guide

--- a/app/index.md
+++ b/app/index.md
@@ -8,7 +8,7 @@ includeInBreadcrumbs: true
 eleventyExcludeFromCollections: false
 inverseMasthead: true
 whatsNewDate: 19 August 2026
-whatsNewHeadline: Updated permissions on making requests to GDS
+whatsNewHeadline: Updated rules on who can request downtime messages, short URLs and specialist finders
 whatsNew: Read more about [recent changes to the guidance](/about-the-guidance/whats-new/).
 gridItems:
   - title: A to Z style guide

--- a/app/index.md
+++ b/app/index.md
@@ -8,7 +8,7 @@ includeInBreadcrumbs: true
 eleventyExcludeFromCollections: false
 inverseMasthead: true
 whatsNewDate: 19 August 2026
-whatsNewHeadline: Updated permissions for making some requests to GDS
+whatsNewHeadline: Updated permissions on making requests to GDS
 whatsNew: Read more about [recent changes to the guidance](/about-the-guidance/whats-new/).
 gridItems:
   - title: A to Z style guide

--- a/app/publish-update-retire-content/organisations-people/organisations.md
+++ b/app/publish-update-retire-content/organisations-people/organisations.md
@@ -465,7 +465,7 @@ There may be exceptions to the list of content types that should not be retagged
 
 If there is too much content for you to retag manually, you can [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) to do a bulk retag. 
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -474,7 +474,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -501,7 +501,7 @@ If anyone is listed under ‘Our management’ on the organisation page, unassig
 
 If anyone is listed under ‘Our ministers’, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) before you update their information.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form.You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -510,7 +510,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/publish-update-retire-content/organisations-people/organisations.md
+++ b/app/publish-update-retire-content/organisations-people/organisations.md
@@ -465,7 +465,18 @@ There may be exceptions to the list of content types that should not be retagged
 
 If there is too much content for you to retag manually, you can [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) to do a bulk retag. 
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 For your request, you’ll need to create and send over a new spreadsheet of the content that need retagging. Only include these columns in the spreadsheet, using these specific headings:
 
@@ -490,7 +501,19 @@ If anyone is listed under ‘Our management’ on the organisation page, unassig
 
 If anyone is listed under ‘Our ministers’, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) before you update their information.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
 
 
 *[GDS]: Government Digital Service

--- a/app/publish-update-retire-content/organisations-people/organisations.md
+++ b/app/publish-update-retire-content/organisations-people/organisations.md
@@ -501,7 +501,7 @@ If anyone is listed under ‘Our management’ on the organisation page, unassig
 
 If anyone is listed under ‘Our ministers’, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) before you update their information.
 
-You'll be taken to a content advice form.You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/publish-update-retire-content/organisations-people/people-roles.md
+++ b/app/publish-update-retire-content/organisations-people/people-roles.md
@@ -40,7 +40,18 @@ GDS will contact GOV.UK leads in ministerial departments to let them know what's
 
 If it's a change to only one or two ministerial appointments, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) to check if you can create and assign the new people and role pages yourself.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 If you can make the changes yourself, ask the minister's private office and the Number 10 digital communications team for the details you can use.
 
@@ -66,7 +77,18 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
 
 If you’re adding a new minister, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 >[!NOTE]
 >When adding or editing a people page, be aware that it will publish or update as soon as you select ‘Save’ – there’s no draft state or peer review.

--- a/app/publish-update-retire-content/organisations-people/people-roles.md
+++ b/app/publish-update-retire-content/organisations-people/people-roles.md
@@ -40,7 +40,7 @@ GDS will contact GOV.UK leads in ministerial departments to let them know what's
 
 If it's a change to only one or two ministerial appointments, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) to check if you can create and assign the new people and role pages yourself.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -49,7 +49,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -69,15 +69,9 @@ If it's a new junior ministerial role with a generic name like 'Minister of Stat
 * Minister of State (Minister for X)
 * Parliamentary Under-Secretary of State (Minister for X)
 
-If you want to make other changes, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval.
+If you want to make other changes, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval. 
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
-
-## Add or edit a people page
-
-If you’re adding a new minister, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval.
-
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -86,7 +80,24 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
+## Add or edit a people page
+
+If you’re adding a new minister, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval.
+
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -124,7 +135,7 @@ For all biographies, do not include information about their personal life, for e
 
 If you’re adding or editing a ministerial role page, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -133,7 +144,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -191,7 +202,7 @@ Do not change anything about the original role or assign it to anyone until it's
 
 If it’s an interim ministerial role, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) before making these changes.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -200,7 +211,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -236,9 +247,9 @@ If there’s no replacement, you need to end their appointment:
 3. Select ‘Edit’ next to their name.
 4. Add the end date and select ‘Save’.
 
-If it’s a ministerial role, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first before making any of these changes.
+If it’s a ministerial role, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first before making any of these changes. 
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -247,7 +258,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/publish-update-retire-content/organisations-people/people-roles.md
+++ b/app/publish-update-retire-content/organisations-people/people-roles.md
@@ -124,7 +124,18 @@ For all biographies, do not include information about their personal life, for e
 
 If you’re adding or editing a ministerial role page, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first to get approval.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 >[!NOTE]
 >When adding or editing a role page, be aware that it will publish or update as soon as you select ‘Save’ or ‘Save and continue’ – there’s no draft state or peer review.
@@ -180,7 +191,18 @@ Do not change anything about the original role or assign it to anyone until it's
 
 If it’s an interim ministerial role, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) before making these changes.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 ## Assign a role to a person
 
@@ -216,7 +238,18 @@ If there’s no replacement, you need to end their appointment:
 
 If it’s a ministerial role, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) first before making any of these changes.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 ### Update the person’s biography
 

--- a/app/publish-update-retire-content/organisations-people/worldwide.md
+++ b/app/publish-update-retire-content/organisations-people/worldwide.md
@@ -336,7 +336,18 @@ There's a navigation page for each country and territory.
 - to edit the title, sections or description of an existing page
 - tag a page to all worldwide locations
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 > [!NOTE]
 > See an [example of a help and services navigation page on GOV.UK](https://www.gov.uk/world/france).
@@ -370,7 +381,19 @@ You can also [ask GDS for help](/accounts-support/get-content-advice/get-help-ad
 * specialist finders
 * travel advice pages
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
 
  
 *[GDS]: Government Digital Service

--- a/app/publish-update-retire-content/organisations-people/worldwide.md
+++ b/app/publish-update-retire-content/organisations-people/worldwide.md
@@ -29,7 +29,7 @@ The 2 types of pages are very similar and are updated in the same way.
 
 You can update an existing world location news page. If you want to add a new one, [ask the Government Digital Service (GDS) for help](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/publish-update-retire-content/organisations-people/worldwide.md
+++ b/app/publish-update-retire-content/organisations-people/worldwide.md
@@ -29,7 +29,7 @@ The 2 types of pages are very similar and are updated in the same way.
 
 You can update an existing world location news page. If you want to add a new one, [ask the Government Digital Service (GDS) for help](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -38,7 +38,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -336,7 +336,7 @@ There's a navigation page for each country and territory.
 - to edit the title, sections or description of an existing page
 - tag a page to all worldwide locations
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -345,7 +345,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -381,7 +381,7 @@ You can also [ask GDS for help](/accounts-support/get-content-advice/get-help-ad
 * specialist finders
 * travel advice pages
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -390,7 +390,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/publish-update-retire-content/organisations-people/worldwide.md
+++ b/app/publish-update-retire-content/organisations-people/worldwide.md
@@ -29,7 +29,18 @@ The 2 types of pages are very similar and are updated in the same way.
 
 You can update an existing world location news page. If you want to add a new one, [ask the Government Digital Service (GDS) for help](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 ### Edit a world locations news page
 

--- a/app/publish-update-retire-content/organisations-people/worldwide.md
+++ b/app/publish-update-retire-content/organisations-people/worldwide.md
@@ -381,7 +381,7 @@ You can also [ask GDS for help](/accounts-support/get-content-advice/get-help-ad
 * specialist finders
 * travel advice pages
 
-You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/publish-update-retire-content/other-content-types/manuals.md
+++ b/app/publish-update-retire-content/other-content-types/manuals.md
@@ -43,7 +43,7 @@ Do not use them for:
 
 ## Get approval to create a new manual
 
-Your GOV.UK lead or a managing editor needs to ask the Government Digital Service (GDS) for approval to create a manual.
+Your GOV.UK lead or managing editor needs to ask the Government Digital Service (GDS) for approval to create a manual.
 
 Their request for a new manual must show:
 
@@ -135,17 +135,41 @@ Users will get email notifications about new manuals or major changes if they're
 
 Your manual will be automatically tagged to the same organisation as your Signon account.
 
-If you want to change the organisation or tag more organisations, [contact GDS using the advice form](https://support.publishing.service.gov.uk/content_advice_request/new).
+If you want to change the organisation or tag more organisations, [contact GDS using the content advice form](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the advice form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
 
 ## Tag to topic pages
 
 You can only tag the manual to topic pages once the first draft is published.
 
-You'll need to [contact GDS using the advice form](https://support.publishing.service.gov.uk/content_advice_request/new) and ask them to tag the manual for you.
+You'll need to [contact GDS using the content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) and ask them to tag the manual for you.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the advice form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
 
 ## Unpublish a manual
 
@@ -160,9 +184,21 @@ To unpublish sections of a manual:
 3. Decide whether you need to [write change notes](/writing-to-gov-uk-standards/tone-of-voice/change-notes/). If you do, select 'Major change' and add your change notes.
 4. When you've done this for every relevant section, publish the draft.
 
-To unpublish the manual as a whole, [contact GDS using the advice form](https://support.publishing.service.gov.uk/content_advice_request/new) and explain why the manual needs to be unpublished.
+To unpublish the manual as a whole, [contact GDS using the content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) and explain why the manual needs to be unpublished.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the advice form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
 
 
 *[GDS]: Government Digital Service

--- a/app/publish-update-retire-content/other-content-types/manuals.md
+++ b/app/publish-update-retire-content/other-content-types/manuals.md
@@ -43,7 +43,7 @@ Do not use them for:
 
 ## Get approval to create a new manual
 
-Your GOV.UK lead or managing editor needs to ask the Government Digital Service (GDS) for approval to create a manual.
+Your GOV.UK lead or a managing editor needs to ask the Government Digital Service (GDS) for approval to create a manual.
 
 Their request for a new manual must show:
 
@@ -137,7 +137,7 @@ Your manual will be automatically tagged to the same organisation as your Signon
 
 If you want to change the organisation or tag more organisations, [contact GDS using the content advice form](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -146,7 +146,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -157,7 +157,7 @@ You can only tag the manual to topic pages once the first draft is published.
 
 You'll need to [contact GDS using the content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) and ask them to tag the manual for you.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -166,7 +166,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -186,7 +186,7 @@ To unpublish sections of a manual:
 
 To unpublish the manual as a whole, [contact GDS using the content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) and explain why the manual needs to be unpublished.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -195,7 +195,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/publish-update-retire-content/other-content-types/specialist-finders.md
+++ b/app/publish-update-retire-content/other-content-types/specialist-finders.md
@@ -31,7 +31,7 @@ Do not use them for:
 
 ## Ask for a new specialist finder
 
-Use the [GOV.UK advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request.
+Use the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request.
 
 You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
@@ -80,7 +80,7 @@ It will usually take developers up to 1 month to make the changes. You can ask f
 
 If you expect multiple changes over a period of time, it'll be easier if you group these together in your request.
 
-If you need access to Specialist Publisher, ask one of your organisation admins. If they cannot give you access themselves, they can [submit an account change request](https://support.publishing.service.gov.uk/change_existing_user_request/new).
+If you need access to Specialist Publisher, ask one of your organisation admins. Your organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  If they cannot give you access themselves, they can [submit an account change request](https://support.publishing.service.gov.uk/change_existing_user_request/new).
 
 ## Writing and formatting requirements for specialist finders
 

--- a/app/publish-update-retire-content/other-content-types/specialist-finders.md
+++ b/app/publish-update-retire-content/other-content-types/specialist-finders.md
@@ -31,7 +31,20 @@ Do not use them for:
 
 ## Ask for a new specialist finder
 
-If you're the GOV.UK lead or a managing editor in your organisation, use the [GOV.UK advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to ask for a new specialist finder.
+Use the [GOV.UK advice form](https://support.publishing.service.gov.uk/content_advice_request/new) to make your request.
+
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 After you've submitted the form, you'll be asked more questions to determine whether a specialist finder is suitable for your content.
 

--- a/app/writing-to-gov-uk-standards/help-users-prepare-change/index.md
+++ b/app/writing-to-gov-uk-standards/help-users-prepare-change/index.md
@@ -45,7 +45,18 @@ In exceptional cases, users might need reassurance in advance that something wil
 
 If you’re unsure, [ask for help from the Government Digital Service (GDS)](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 ## Review content that already exists
 

--- a/app/writing-to-gov-uk-standards/help-users-prepare-change/index.md
+++ b/app/writing-to-gov-uk-standards/help-users-prepare-change/index.md
@@ -54,7 +54,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 

--- a/app/writing-to-gov-uk-standards/help-users-prepare-change/index.md
+++ b/app/writing-to-gov-uk-standards/help-users-prepare-change/index.md
@@ -45,7 +45,7 @@ In exceptional cases, users might need reassurance in advance that something wil
 
 If you’re unsure, [ask for help from the Government Digital Service (GDS)](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
@@ -32,7 +32,7 @@ Govsearch will not show content that's published using non-GOV.UK tools, includi
 
 [Ask the Government Digital Service (GDS) for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you would like to search this other content.
 
-You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
@@ -128,7 +128,7 @@ If your organisation is not tagged, they can direct you to the tagged organisati
 
 [Ask GDS for help if you want to change mainstream content](/accounts-support/make-content-requests/ask-updates-content/).
 
-You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
@@ -32,7 +32,19 @@ Govsearch will not show content that's published using non-GOV.UK tools, includi
 
 [Ask the Government Digital Service (GDS) for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you would like to search this other content.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
+
 
 ### If you're only interested in Whitehall Publisher
 

--- a/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
@@ -32,7 +32,7 @@ Govsearch will not show content that's published using non-GOV.UK tools, includi
 
 [Ask the Government Digital Service (GDS) for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you would like to search this other content.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the content advice form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -41,7 +41,7 @@ You’ll need a Signon account with ‘content requesters’ permissions to acce
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 
@@ -105,7 +105,18 @@ If the page is tagged to other organisations and not yours, contact their contac
 
 [Ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new) if you need contact information for other content teams.
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. Speak to your GOV.UK lead or managing editor if you want access to the form.
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 ### If your content is on a 'mainstream' page
 
@@ -117,7 +128,18 @@ If your organisation is not tagged, they can direct you to the tagged organisati
 
 [Ask GDS for help if you want to change mainstream content](/accounts-support/make-content-requests/ask-updates-content/).
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 ### If your content is on any other type of page
 
@@ -127,7 +149,18 @@ You will not be able to update content if it's in 'history mode'. If it's in his
 
 If you want to update content in history mode, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the content advice form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 
 *[GDS]: Government Digital Service

--- a/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
+++ b/app/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content.md
@@ -149,7 +149,7 @@ You will not be able to update content if it's in 'history mode'. If it's in his
 
 If you want to update content in history mode, [ask GDS for help](https://support.publishing.service.gov.uk/content_advice_request/new).
 
-You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the request form. 
+You'll be taken to a content advice form. You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
+++ b/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
@@ -57,7 +57,7 @@ Consider whether there's a cross-government need for a consistent style. If the 
 
 Raise a ticket using the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). 
 
- You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
+You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
+++ b/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
@@ -57,7 +57,18 @@ Consider whether there's a cross-government need for a consistent style. If the 
 
 [Raise a support ticket](https://support.publishing.service.gov.uk/content_advice_request/new). 
 
-You'll need a GOV.UK Signon account with ‘content requesters’ permissions to raise a support ticket. If you do not have one, speak to your GOV.UK lead or managing editor to send a ticket for you or arrange access to the support request form.
+ You’ll need a Signon account with ‘content requesters’ permissions to raise a support ticket. 
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      If you do not have access to the supoprt request form
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+  </div>
+</details>
 
 In your ticket, include:
 

--- a/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
+++ b/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
@@ -55,9 +55,9 @@ Consider whether there's a cross-government need for a consistent style. If the 
 
 ### How to suggest a change
 
-[Raise a support ticket](https://support.publishing.service.gov.uk/content_advice_request/new). 
+Raise a ticket using the [content advice form](https://support.publishing.service.gov.uk/content_advice_request/new). 
 
- You’ll need a Signon account with ‘content requesters’ permissions to raise a support ticket using the content advice form. 
+ You’ll need a Signon account with ‘content requesters’ permissions to access the form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
+++ b/app/writing-to-gov-uk-standards/style-guides/how-to-use.md
@@ -57,16 +57,16 @@ Consider whether there's a cross-government need for a consistent style. If the 
 
 [Raise a support ticket](https://support.publishing.service.gov.uk/content_advice_request/new). 
 
- You’ll need a Signon account with ‘content requesters’ permissions to raise a support ticket. 
+ You’ll need a Signon account with ‘content requesters’ permissions to raise a support ticket using the content advice form. 
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      If you do not have access to the supoprt request form
+      If you do not have access to the content advice form
     </span>
   </summary>
   <div class="govuk-details__text">
-    Speak to your GOV.UK lead or one of the organisation admins if you want access to the form. Your GOV.UK lead or organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
+    Speak to your GOV.UK lead or one of your organisation admins if you want access to the form. Your GOV.UK lead and organisation admins will typically be in your organisation’s GOV.UK content, digital content, publishing or digital communications team.  
   </div>
 </details>
 


### PR DESCRIPTION
Amended ask for a short URL page to add detail component for it users cannot access the content advice form. 

Changed 'managing editor' to 'one of the organisation admins'.

Made same change on other pages where users have to sign into the access the content advice form. 