### PR TITLE
Add link to new blog request form

### DIFF
--- a/app/about-the-guidance/whats-new.md
+++ b/app/about-the-guidance/whats-new.md
@@ -14,6 +14,7 @@ This page sets out all recent major updates to the GOV.UK content and publishing
 
 | Date | Section | Update |
 | --------- | ----------- | ----------- |
+| 17 August | [Blogs](/publish-update-retire-content/promotional-social/blogs/) | Added a link to the new blog request form. |
 | 11 August | [A to Z style guide](/writing-to-gov-uk-standards/style-guides/a-to-z-style-guide/) | Updated entry for 'Ofsted judgements' to reflect new grading system. |
 | 5 August | [Ask for limited access to drafts to be changed](/accounts-support/make-content-requests/ask-access-limit-reset/) | Added guidance on how to ask for limited access to drafts to be changed. |
 | 4 August | [Retire outdated content](/writing-to-gov-uk-standards/plan-manage-content/retire-content/) | Updated the section on history mode to make it clearer which content types can go into history mode. |

--- a/app/index.md
+++ b/app/index.md
@@ -7,8 +7,8 @@ description: Read the standards for digital content and find out how to use the 
 includeInBreadcrumbs: true
 eleventyExcludeFromCollections: false
 inverseMasthead: true
-whatsNewDate: 11 August 2026
-whatsNewHeadline: Updated style guide entry for 'Ofsted judgements' to reflect new grading system
+whatsNewDate: 17 August 2026
+whatsNewHeadline: Added a link to the new blog request form
 whatsNew: Read more about [recent changes to the guidance](/about-the-guidance/whats-new/).
 gridItems:
   - title: A to Z style guide

--- a/app/publish-update-retire-content/promotional-social/blogs.md
+++ b/app/publish-update-retire-content/promotional-social/blogs.md
@@ -51,7 +51,7 @@ You will need to request a blog from the Government Digital Service (GDS).
 
 1. Get approval from your GOV.UK lead or a managing editor.
 2. Figure out who would be the blog's owner. They are the main point of contact with GDS.
-3. Complete the [blog request form](https://docs.google.com/a/digital.cabinet-office.gov.uk/forms/d/1PqhvADUF8_6Zw02w5QtveyjqlMiMWh6COOfPYAuUre8/viewform?edit_requested=true). Contact <blogeditors@digital.cabinet-office.gov.uk> for an alternative version if you cannot access the form.
+3. Complete the [blog request form](https://forms.cloud.microsoft/e/qipzYFUZ7Q?origin=lprLink). Contact <blogeditors@digital.cabinet-office.gov.uk> for an alternative version if you cannot access the form.
 
 All new blog requests are dealt with in the order they're received. It may take up to one month to get a response.
 


### PR DESCRIPTION
Updated the link that users need to use to request a new blog. The blog team is replacing the form as part of the GDS move from Google to Microsoft.

Also updated the 'What's new' information. It's not a huge change, but I'm just being cautious in case there are users who bookmarked the old form.